### PR TITLE
Selection output type

### DIFF
--- a/radis/core/static/core/core.css
+++ b/radis/core/static/core/core.css
@@ -39,3 +39,34 @@
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 }
+
+.selection-options-controls,
+.selection-options-actions {
+  gap: 0.5rem;
+}
+
+.array-toggle-field {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-top: 14px;
+}
+
+.array-toggle-btn {
+  width: calc(2.5rem - 6px);
+  height: calc(2.5rem - 6px);
+  border-radius: 50%;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  line-height: 1;
+  font-size: 1rem;
+}
+
+.array-toggle-btn.active {
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
+  color: #fff;
+}

--- a/radis/core/static/core/core.js
+++ b/radis/core/static/core/core.js
@@ -46,6 +46,27 @@ document.addEventListener("alpine:init", () => {
   });
 });
 
+// Prevent form submission on Enter keypress for forms with data-prevent-enter-submit.
+// This was added to the Extractions Output Fields Page to prevent form submission
+// on pressing Enter while adding Output Fields.
+document.addEventListener("DOMContentLoaded", () => {
+  const preventAttr = "[data-prevent-enter-submit]";
+  document.querySelectorAll(preventAttr).forEach((formEl) => {
+    formEl.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter") {
+        return;
+      }
+      const target = event.target;
+      const isTextInput =
+        target instanceof HTMLInputElement &&
+        !["submit", "button"].includes(target.type);
+      if (isTextInput) {
+        event.preventDefault();
+      }
+    });
+  });
+});
+
 /**
  * An Alpine component that controls a Django FormSet
  *
@@ -86,6 +107,225 @@ function FormSet(rootEl) {
       const idx = totalForms.value;
       totalForms.value = (parseInt(idx) - 1).toString();
       this.formCount = parseInt(totalForms.value);
+    },
+  };
+}
+
+/**
+ * Manages the dynamic selection options input for extraction output fields.
+ *
+ *  An Alpine component that controls a Django FormSet.
+ * The core idea is to create a small state machine that manages --
+ * 1. A list of "Selection Option" strings (like an enum)
+ * 2. Whether the current output field supports selections
+ * 3. Whether the field should return multiple values (isArray).
+ * 4. A snapshot of the last valid selections so we can restore them if the user
+ * toggles output types (lastSelectionOptions).
+ * 5. Keeping the hidden inputs (JSON representations of users dynamic input)
+ * synced so Django can read the state when the form submits.
+ *
+ * @param {HTMLElement} rootEl
+ * @returns {Object}
+ */
+function SelectionOptions(rootEl) {
+  /*data-selection-input and data-array-input are data attributes that are used to 
+  locate the the hidden fields that store the JSON serialized state.*/
+  const hiddenInput = rootEl.querySelector("[data-selection-input]");
+  const arrayInput = rootEl.querySelector("[data-array-input]");
+
+  /*finds the closest wrapper that contains the output-type dropdown and the toggle button */
+  const formContainer =
+    rootEl.closest(".formset-form") ?? rootEl.closest("form") ?? rootEl;
+
+  /*We are searching for the <select> element that controls the output type 
+    (e.g., Text, Numeric, Boolean, Selection). The name attribute of that 
+    <select> differs based on whether we are in a formset or a single form,
+    so we try both patterns here - this is important in case we want to use this component 
+    outside of a formset in the future. */
+  const outputTypeField =
+    formContainer.querySelector('select[name$="-output_type"]') ??
+    formContainer.querySelector('select[name="output_type"]');
+  const arrayToggleButton =
+    formContainer.querySelector("[data-array-toggle]") ?? null;
+
+  /*Takes the string from the hidden is_array field and turns it into a boolean.*/
+  const parseArrayValue = (value) => {
+    if (!value) {
+      return false;
+    }
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "1" || normalized === "on";
+  };
+  const maxSelectionOptions = outputTypeField?.dataset.maxSelectionOptions;
+
+  /*Reads the maximum number of selections allowed. 
+  Each form field embeds this limit via data-max-selection-options
+  which is set in the initialization of OutputFieldForm */
+  const parseMaxOptions = () => {
+    const datasetValue =
+      hiddenInput?.dataset.maxSelectionOptions ??
+      rootEl.dataset.maxSelectionOptions ??
+      "";
+    const parsed = Number.parseInt(datasetValue, 10);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+  const initialMaxOptions = parseMaxOptions();
+
+  //This represents the "reactive state" (summary of users dynamic input) of the component.
+  return {
+    options: [], //array of current selection strings displayed in the widget.
+    maxOptions: initialMaxOptions,
+    supportsSelection: false, //whether the current output type supports selection options.
+    isArray: parseArrayValue(arrayInput?.value), //current "array toggle" state,
+    // parsed from the hidden field.
+    lastSelectionOptions: [], // used to remember the user’s typed options if they
+    // switch away from Selection so we can restore them later.
+
+    init() {
+      //Populate options by reading the hidden JSON string (if any).
+      this.options = this.parseOptions(hiddenInput?.value);
+      //isArray based on the hidden is_array value.
+      this.isArray = parseArrayValue(arrayInput?.value);
+      //Remember the initial options in lastSelectionOptions.
+      this.lastSelectionOptions = [...this.options];
+      this.updateSupports(); //Determine if current output type supports selection.
+
+      //Clicking the button flips isArray
+      if (arrayToggleButton) {
+        arrayToggleButton.addEventListener("click", (event) => {
+          event.preventDefault();
+          this.toggleArray();
+        });
+        this.updateArrayButton();
+      }
+      if (outputTypeField) {
+        outputTypeField.addEventListener("change", () => {
+          /**
+           * When the user switches from Selection to another type, we save the current
+           * options in lastSelectionOptions and clear options and clear the UI
+           * (since we shouldn’t show them for Text/Numeric/Boolean).
+           *
+           * If they switch back to Selection and there are no options yet,
+           *  we restore the previous list (or reload from the hidden JSON).
+           *
+           * This prevents data loss when toggling between types.
+           */
+          const wasSelection = this.supportsSelection;
+          this.updateSupports();
+          if (!this.supportsSelection) {
+            this.lastSelectionOptions = [...this.options];
+            this.options = [];
+          } else if (!wasSelection && this.options.length === 0) {
+            if (this.lastSelectionOptions.length > 0) {
+              this.options = [...this.lastSelectionOptions];
+            } else {
+              this.options = this.parseOptions(hiddenInput?.value);
+            }
+          }
+        });
+      }
+    },
+
+    /* Converts the hidden field’s JSON string into a clean array of strings. 
+    Non-string entries become empty strings and get filtered out.*/
+    parseOptions(value) {
+      if (!value) {
+        return [];
+      }
+      try {
+        const parsed = JSON.parse(value);
+        if (Array.isArray(parsed)) {
+          return parsed
+            .map((opt) => (typeof opt === "string" ? opt : ""))
+            .filter((opt) => opt !== "");
+        }
+      } catch (err) {
+        console.warn("Invalid selection options payload", err);
+      }
+      return [];
+    },
+
+    //Checks the dropdown’s current value. If the field is set to S (Selection),
+    // we show the options list. Otherwise, hide it..
+    updateSupports() {
+      this.supportsSelection = outputTypeField
+        ? outputTypeField.value === "S"
+        : false;
+    },
+
+    /*
+    Whenever the options array changes, we trim entries, remove empty strings, serialize to JSON, 
+    and store it back in the hidden input. 
+    We also update lastSelectionOptions so we remember the sanitized state.
+    */
+    syncOptions() {
+      if (!hiddenInput) {
+        return;
+      }
+      const sanitized = this.options
+        .map((opt) => (typeof opt === "string" ? opt.trim() : ""))
+        .filter((opt) => opt !== "");
+      hiddenInput.value = JSON.stringify(sanitized);
+      this.lastSelectionOptions = [...sanitized];
+    },
+
+    //Writes "true" or "false" into the hidden is_array input.
+    syncArray() {
+      if (!arrayInput) {
+        return;
+      }
+      arrayInput.value = this.isArray ? "true" : "false";
+    },
+
+    /*
+      One method to sync everything. 
+      We call this via x-effect="syncState()" in the template, 
+      so Alpine runs it after every reactive update
+    */
+    syncState() {
+      this.syncOptions();
+      this.syncArray();
+      this.updateArrayButton();
+    },
+
+    //Adds a new empty option if the field is in Selection mode and hasn’t hit the max count.
+    addOption() {
+      if (!this.supportsSelection || this.options.length >= this.maxOptions) {
+        return;
+      }
+      this.options.push("");
+      this.$nextTick(() => {
+        // After adding, it waits for the DOM to update ($nextTick) and automatically shifts cursor focus
+        // to the newly added input field.
+        const inputs = rootEl.querySelectorAll("[data-selection-option-input]");
+        const lastInput = inputs[inputs.length - 1];
+        if (lastInput instanceof HTMLInputElement) {
+          lastInput.focus();
+        }
+      });
+    },
+
+    //Deletes the option at the selected index.
+    removeOption(index) {
+      this.options.splice(index, 1);
+    },
+
+    //Flips the boolean; syncState() will update the hidden input and button appearance.
+    toggleArray() {
+      this.isArray = !this.isArray;
+    },
+
+    //Updates the toggle button’s appearance based on isArray state -
+    // we want to show a blue highlight around the button when it is pressed (shows active state).
+    updateArrayButton() {
+      if (!arrayToggleButton) {
+        return;
+      }
+      arrayToggleButton.classList.toggle("active", this.isArray);
+      arrayToggleButton.setAttribute(
+        "aria-pressed",
+        this.isArray ? "true" : "false"
+      );
     },
   };
 }

--- a/radis/core/templates/cotton/formset.html
+++ b/radis/core/templates/cotton/formset.html
@@ -3,12 +3,12 @@
 <fieldset x-data="FormSet($el)" class="mb-3">
     {% if legend %}<legend>{{ legend }}</legend>{% endif %}
     {{ formset.management_form }}
-    <template>
-        <c-formset-form>{% crispy formset.empty_form %}</c-formset-form>
-    </template>
-    <div class="formset-forms">
-        {% for form in formset %}<c-formset-form>{{ form|crispy }}</c-formset-form>{% endfor %}
-    </div>
+<template>
+    <c-formset-form>{% crispy formset.empty_form %}</c-formset-form>
+</template>
+<div class="formset-forms">
+    {% for form in formset %}<c-formset-form>{% crispy form %}</c-formset-form>{% endfor %}
+</div>
     {% if add_form_label %}
         <div class="d-flex flex-row-reverse">
             <button type="button"

--- a/radis/extractions/constants.py
+++ b/radis/extractions/constants.py
@@ -1,0 +1,2 @@
+MAX_SELECTION_OPTIONS = 7.0  # Maximum number of Enum values (selection output types) a
+# user can add per Output Field the Extraction Output Fields Page.

--- a/radis/extractions/forms.py
+++ b/radis/extractions/forms.py
@@ -1,8 +1,9 @@
+import json
 from typing import Any, cast
 
 from adit_radis_shared.accounts.models import User
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Column, Layout, Row, Submit
+from crispy_forms.layout import HTML, Column, Div, Layout, Row, Submit
 from django import forms
 from django.conf import settings
 from django.db.models import QuerySet
@@ -14,7 +15,8 @@ from radis.search.forms import AGE_STEP, MAX_AGE, MIN_AGE
 from radis.search.site import Search, SearchFilters
 from radis.search.utils.query_parser import QueryParser
 
-from .models import ExtractionJob, OutputField
+from .constants import MAX_SELECTION_OPTIONS
+from .models import ExtractionJob, OutputField, OutputType
 from .site import extraction_retrieval_providers
 
 
@@ -185,13 +187,152 @@ class SearchForm(forms.ModelForm):
 
 
 class OutputFieldForm(forms.ModelForm):
+    """Hidden field to store selection options and array flag as JSON string.
+    This is done because the selection options are dynamic and the array toggle
+    is an alpine component that needs to be re-rendered on every change."""
+
+    selection_options = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput(),
+    )
+    is_array = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput(),
+    )
+
     class Meta:
         model = OutputField
         fields = [
             "name",
             "description",
             "output_type",
+            "selection_options",
+            "is_array",
         ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["description"].widget = forms.Textarea(attrs={"rows": 3})
+
+        # Stamp data attributes so the selection-options widget can locate these fields.
+        self.fields["selection_options"].widget.attrs.update(
+            {
+                "data-selection-input": "true",
+                "data-max-selection-options": str(MAX_SELECTION_OPTIONS),
+            }
+        )
+        self.fields["is_array"].widget.attrs.update(
+            {
+                "data-array-input": "true",
+            }
+        )
+
+        initial_options = self.instance.selection_options if self.instance.pk else []
+
+        # Prepopulate the hidden fields so existing options/toggle state show up in the widget.
+        self.initial["selection_options"] = json.dumps(initial_options)
+        self.initial["is_array"] = "true" if self.instance.is_array else "false"
+
+        self.helper = FormHelper()
+        self.helper.form_tag = False  # because we want to define only the inner layout
+        self.helper.disable_csrf = True
+
+        # Build the layout for selection options and array toggle button using crispy.
+        self.helper.layout = Layout(
+            Row(
+                Column("name", css_class="col-md-7 col-12"),
+                Column("output_type", css_class="col-md-4 col-10"),
+                Column(
+                    HTML(
+                        (
+                            '<button type="button" '
+                            'class="btn btn-outline-secondary btn-sm array-toggle-btn '
+                            'form-array-toggle" '
+                            'data-array-toggle="true" '
+                            'aria-pressed="false" '
+                            'title="Toggle array output">[ ]</button>'
+                        )
+                    ),
+                    css_class=(
+                        "col-md-1 col-2 d-flex align-items-center "
+                        "justify-content-end array-toggle-field"
+                    ),
+                ),
+                css_class="g-3 align-items-center",
+            ),
+            "description",
+            # Include the selection options widget partial template here.
+            Div(
+                HTML('{% include "extractions/_selection_options_field.html" %}'),
+                css_class="selection-options-wrapper",
+            ),
+        )
+
+    # Parse and sanitize the JSON payload (trim strings, enforce uniqueness and max count).
+    # Called automatically by Django form validation.
+    def clean_selection_options(self) -> list[str]:
+        raw_value = self.cleaned_data.get("selection_options") or ""
+        raw_value = raw_value.strip()
+        if raw_value == "":
+            return []
+
+        try:
+            parsed = json.loads(raw_value)
+        except json.JSONDecodeError as exc:
+            raise forms.ValidationError("Invalid selection data.") from exc
+
+        if not isinstance(parsed, list):
+            raise forms.ValidationError("Selection data must be a list.")
+
+        cleaned: list[str] = []
+        for item in parsed:
+            if not isinstance(item, str):
+                raise forms.ValidationError("Selection options must be text.")
+            value = item.strip()
+            if not value:
+                raise forms.ValidationError("Selection options cannot be empty.")
+            cleaned.append(value)
+
+        if len(cleaned) > MAX_SELECTION_OPTIONS:
+            raise forms.ValidationError(
+                f"Provide at most {MAX_SELECTION_OPTIONS} selection options."
+            )
+        if len(set(cleaned)) != len(cleaned):
+            raise forms.ValidationError("Selection options must be unique.")
+
+        return cleaned
+
+    # not exactly needed because we set the value ourselves, but more as a double check
+    def clean_is_array(self) -> bool:
+        raw_value = (self.cleaned_data.get("is_array") or "").strip().lower()
+        if raw_value in {"1", "true", "on"}:
+            return True
+        return False
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if not cleaned_data:
+            return cleaned_data
+
+        output_type = cleaned_data.get("output_type")
+        selection_options: list[str] = cleaned_data.get("selection_options") or []
+
+        if output_type == OutputType.SELECTION:
+            if not selection_options:
+                self.add_error(
+                    "selection_options",
+                    "Add at least one selection to use the Selection type.",
+                )
+        else:
+            if selection_options:
+                self.add_error(
+                    "selection_options",
+                    "Selections are only allowed when Output Type is Selection.",
+                )
+                cleaned_data["selection_options"] = []
+
+        return cleaned_data
 
 
 OutputFieldFormSet = forms.inlineformset_factory(

--- a/radis/extractions/migrations/0004_outputfield_selection_options.py
+++ b/radis/extractions/migrations/0004_outputfield_selection_options.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("extractions", "0003_alter_extractionjob_options_and_more"),
+    ]
+
+    operations = [
+
+        # Introduce a JSON column to store the Selection output fields.
+        migrations.AddField(
+            model_name="outputfield",
+            name="selection_options",
+            field=models.JSONField(blank=True, default=list),
+        ),
+
+        # Extend the output_type choices so the database accepts the new Selection code ("S").
+        migrations.AlterField(
+            model_name="outputfield",
+            name="output_type",
+            field=models.CharField(
+                choices=[
+                    ("T", "Text"),
+                    ("N", "Numeric"),
+                    ("B", "Boolean"),
+                    ("S", "Selection"),
+                ],
+                default="T",
+                max_length=1,
+            ),
+        ),
+    ]

--- a/radis/extractions/migrations/0005_outputfield_is_array.py
+++ b/radis/extractions/migrations/0005_outputfield_is_array.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("extractions", "0004_outputfield_selection_options"),
+    ]
+
+    operations = [
+        # Track whether an output field should return a list of values rather than a single value.
+        migrations.AddField(
+            model_name="outputfield",
+            name="is_array",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/radis/extractions/models.py
+++ b/radis/extractions/models.py
@@ -11,6 +11,8 @@ from procrastinate.contrib.django.models import ProcrastinateJob
 from radis.core.models import AnalysisJob, AnalysisTask
 from radis.reports.models import Language, Modality, Report
 
+from .constants import MAX_SELECTION_OPTIONS
+
 
 class ExtractionsAppSettings(AppSettings):
     class Meta:
@@ -76,6 +78,9 @@ class OutputType(models.TextChoices):
     TEXT = "T", "Text"
     NUMERIC = "N", "Numeric"
     BOOLEAN = "B", "Boolean"
+    SELECTION = "S", "Selection"  # New output type which works like a enum
+    # Allows user to define a set of options which the LLM can
+    # choose from to answer questions.
 
 
 class OutputField(models.Model):
@@ -86,6 +91,11 @@ class OutputField(models.Model):
     )
     get_output_type_display: Callable[[], str]
     optional = models.BooleanField(default=False)
+    # For Selection output type, stores the list of allowed options.
+    # Only used if output_type == OutputType.SELECTION.
+    selection_options = models.JSONField(default=list, blank=True)
+    # Whether the field should return an array of values or just values.
+    is_array = models.BooleanField(default=False)
     job = models.ForeignKey[ExtractionJob](
         ExtractionJob, on_delete=models.CASCADE, related_name="output_fields"
     )
@@ -100,6 +110,47 @@ class OutputField(models.Model):
 
     def __str__(self) -> str:
         return f'Output Field "{self.name}" [{self.pk}]'
+
+    def clean(self) -> None:
+        """Custom validation logic for Selection output type
+        Checks for non empty, uniqueness, and max number of options."""
+
+        from django.core.exceptions import ValidationError
+
+        super().clean()  # Call Django's field validators and other checks first
+
+        if self.output_type == OutputType.SELECTION:
+            if not self.selection_options:
+                raise ValidationError({"selection_options": "Add at least one selection option."})
+            if len(self.selection_options) > MAX_SELECTION_OPTIONS:
+                raise ValidationError(
+                    {
+                        "selection_options": (
+                            f"Provide at most {MAX_SELECTION_OPTIONS} selection options."
+                        )
+                    }
+                )
+            cleaned_options = []
+            for option in self.selection_options:
+                if not isinstance(option, str):
+                    raise ValidationError(
+                        {"selection_options": "All selection options must be text."}
+                    )
+                stripped = option.strip()
+                if not stripped:
+                    raise ValidationError(
+                        {"selection_options": "Selection options cannot be empty strings."}
+                    )
+                cleaned_options.append(stripped)
+            if len(set(cleaned_options)) != len(cleaned_options):
+                raise ValidationError({"selection_options": "Selection options must be unique."})
+            self.selection_options = cleaned_options
+        else:
+            if self.selection_options:
+                raise ValidationError(
+                    {"selection_options": "Selections are only allowed for the Selection type."}
+                )
+            self.selection_options = []
 
 
 class ExtractionTask(AnalysisTask):

--- a/radis/extractions/templates/extractions/_selection_options_field.html
+++ b/radis/extractions/templates/extractions/_selection_options_field.html
@@ -1,0 +1,51 @@
+<!-- Provide a dynamic UI for entering selection options (add/remove inputs) and toggling array output. 
+There’s no built-in HTML control for “editable list,” so we build one with Alpine  -->
+{% load bootstrap_icon from common_extras %}
+<div class="mt-3"
+     x-data="SelectionOptions($el)"
+     x-effect="syncState()"
+     data-selection-wrapper="true">
+    <!-- Hidden fields must appear first so the Alpine component can read/write its state -->
+    {{ form.selection_options }}
+    {{ form.is_array }}
+    <div class="d-flex align-items-center flex-wrap selection-options-controls">
+        <div class="d-flex align-items-center gap-2 flex-wrap selection-options-actions">
+            <button type="button"
+                    class="btn btn-outline-secondary btn-sm"
+                    @click.prevent="addOption()"
+                    :disabled="!supportsSelection || options.length >= maxOptions">
+                {% bootstrap_icon "plus-lg" %}
+                Enter a selection
+            </button>
+            <small class="text-muted"
+                   x-show="supportsSelection"
+                   x-text="`${options.length} / ${maxOptions}`"></small>
+        </div>
+    </div>
+    <div class="mt-2" x-show="supportsSelection">
+        <!-- Each entry binds to options[index] so that we can list all the added selection options -->
+        <template x-for="(option, index) in options" :key="index">
+            <div class="input-group mb-2">
+                <input type="text"
+                       class="form-control"
+                       :placeholder="`Selection ${index + 1}`"
+                       data-selection-option-input
+                       x-model="options[index]">
+                <button type="button"
+                        class="btn btn-outline-danger"
+                        @click.prevent="removeOption(index)"
+                        aria-label="Remove selection option">{% bootstrap_icon "trash" %}</button>
+            </div>
+        </template>
+        <p class="text-muted fst-italic" x-show="options.length === 0">No selections defined yet.</p>
+    </div>
+    <p class="text-muted fst-italic" x-show="!supportsSelection">
+        Choose the “Selection” output type to define enumerated values.
+    </p>
+    <!-- Server-side validation errors from the Django form appear here -->
+    {% if form.selection_options.errors %}
+        <div class="invalid-feedback d-block">
+            {% for error in form.selection_options.errors %}{{ error }}{% endfor %}
+        </div>
+    {% endif %}
+</div>

--- a/radis/extractions/templates/extractions/extraction_job_detail.html
+++ b/radis/extractions/templates/extractions/extraction_job_detail.html
@@ -114,6 +114,22 @@
                     <dd class="col-sm-9">
                         {{ field.output_type|human_readable_output_type }}
                     </dd>
+                    {% if field.is_array %}
+                        <dt class="col-sm-3">Array Output</dt>
+                        <dd class="col-sm-9">
+                            Yes — return multiple {{ field.output_type|human_readable_output_type|lower }} values
+                        </dd>
+                    {% endif %}
+                    {% if field.selection_options %}
+                        <dt class="col-sm-3">Selections</dt>
+                        <dd class="col-sm-9">
+                            <ul class="mb-0 ps-3">
+                                {% for option in field.selection_options %}
+                                    <li>{{ option }}</li>
+                                {% endfor %}
+                            </ul>
+                        </dd>
+                    {% endif %}
                 </dl>
             </li>
         {% endfor %}

--- a/radis/extractions/templates/extractions/extraction_job_wizard_summary.html
+++ b/radis/extractions/templates/extractions/extraction_job_wizard_summary.html
@@ -91,6 +91,22 @@
                                 <dd class="col-sm-9">
                                     {{ field.output_type|human_readable_output_type }}
                                 </dd>
+                                {% if field.is_array %}
+                                    <dt class="col-sm-3">Array Output</dt>
+                                    <dd class="col-sm-9">
+                                        Yes — return multiple {{ field.output_type|human_readable_output_type|lower }} values
+                                    </dd>
+                                {% endif %}
+                                {% if field.selection_options %}
+                                    <dt class="col-sm-3">Selections</dt>
+                                    <dd class="col-sm-9">
+                                        <ul class="mb-0 ps-3">
+                                            {% for option in field.selection_options %}
+                                                <li>{{ option }}</li>
+                                            {% endfor %}
+                                        </ul>
+                                    </dd>
+                                {% endif %}
                             </dl>
                         </li>
                     {% endif %}
@@ -98,7 +114,10 @@
             </ul>
         </dd>
     </dl>
-    <form action="" method="post" class="pt-3">
+    <form action=""
+          method="post"
+          class="pt-3"
+          data-prevent-enter-submit="true">
         {% csrf_token %}
         {{ wizard.management_form }}
         {% crispy form %}

--- a/radis/extractions/tests/unit/test_processor_utils.py
+++ b/radis/extractions/tests/unit/test_processor_utils.py
@@ -1,0 +1,48 @@
+from typing import Literal, get_args, get_origin
+
+import pytest
+
+from radis.extractions.factories import ExtractionJobFactory, OutputFieldFactory
+from radis.extractions.models import OutputType
+from radis.extractions.utils.processor_utils import generate_output_fields_schema
+
+
+@pytest.mark.django_db
+def test_generate_output_fields_schema_uses_literal_for_selection_fields():
+    job = ExtractionJobFactory.create()
+    field = OutputFieldFactory(
+        job=job,
+        name="grade",
+        output_type=OutputType.SELECTION,
+    )
+    field.selection_options = ["Grade 1", "Grade 2"]
+    field.save()
+
+    schema = generate_output_fields_schema(job.output_fields)
+
+    grade_field = schema.model_fields["grade"]
+    annotation = grade_field.annotation
+    assert get_origin(annotation) is Literal
+    assert set(get_args(annotation)) == {"Grade 1", "Grade 2"}
+
+
+@pytest.mark.django_db
+def test_generate_output_fields_schema_wraps_literal_in_list_for_array_selections():
+    job = ExtractionJobFactory.create()
+    field = OutputFieldFactory(
+        job=job,
+        name="grade_multi",
+        output_type=OutputType.SELECTION,
+    )
+    field.selection_options = ["High", "Low"]
+    field.is_array = True
+    field.save()
+
+    schema = generate_output_fields_schema(job.output_fields)
+
+    grade_field = schema.model_fields["grade_multi"]
+    annotation = grade_field.annotation
+    assert get_origin(annotation) is list
+    (inner_annotation,) = get_args(annotation)
+    assert get_origin(inner_annotation) is Literal
+    assert set(get_args(inner_annotation)) == {"High", "Low"}

--- a/radis/extractions/utils/processor_utils.py
+++ b/radis/extractions/utils/processor_utils.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 
 from django.db.models import QuerySet
 from pydantic import BaseModel, create_model
@@ -7,18 +7,33 @@ from ..models import OutputField, OutputType
 
 type Numeric = float | int
 
+"""Build a Pydantic model that describes the structure the extractor must output"""
+
 
 def generate_output_fields_schema(fields: QuerySet[OutputField]) -> type[BaseModel]:
     field_definitions: dict[str, Any] = {}
     for field in fields.all():
-        if field.output_type == OutputType.TEXT:
+        field_type = OutputType(field.output_type)
+        if field_type == OutputType.TEXT:
             output_type = str
-        elif field.output_type == OutputType.NUMERIC:
+        elif field_type == OutputType.NUMERIC:
             output_type = Numeric
-        elif field.output_type == OutputType.BOOLEAN:
+        elif field_type == OutputType.BOOLEAN:
             output_type = bool
+        elif field_type == OutputType.SELECTION:
+            # Grab the saved selection_options list and convert it to a tuple.
+            options = tuple(field.selection_options)
+            if not options:
+                raise ValueError("Selection output requires at least one option.")
+            # Set the output type to a Literal of the options so that only these values
+            # can be accepted.
+            output_type = Literal[*options]
         else:
             raise ValueError(f"Unknown data type: {field.output_type}")
+
+        if field.is_array:
+            # If the field stores multiple values, use a list[...] of the base type above.
+            output_type = list[output_type]
 
         field_definitions[field.name] = (output_type, ...)
 
@@ -26,8 +41,21 @@ def generate_output_fields_schema(fields: QuerySet[OutputField]) -> type[BaseMod
 
 
 def generate_output_fields_prompt(fields: QuerySet[OutputField]) -> str:
+    # Build a human-readable prompt that mirrors the same selection/array rules.
     prompt = ""
     for field in fields.all():
-        prompt += f"{field.name}: {field.description}\n"
+        description = field.description
+        if OutputType(field.output_type) == OutputType.SELECTION and field.selection_options:
+            # Tell the processor exactly which selections it may return.
+            description = (
+                f"{description} (Allowed selections: {', '.join(field.selection_options)})"
+            )
+        if field.is_array:
+            # Remind the processor to return an array, not a single value.
+            description = (
+                f"{description} (Return an array of "
+                f"{field.get_output_type_display().lower()} values.)"
+            )
+        prompt += f"{field.name}: {description}\n"
 
     return prompt


### PR DESCRIPTION
Adding a "Selection Output Type" to the list of possible output types like Text, Boolean, Numeric. This essentially behaves like a enum type - It accepts (for now upto 7) possible options (or lets say "Selections"), which are then sent to the LLM and the LLM is asked to choose one of the "Selections" as answer. 

The form is rendered by adding an Alpine component called SelectionOptions. A new template is created to serve the form called _selection_options_field. Other templates that small updates are extraction_job_detail adn extraction_job_wizard_summary, because out new selection type has to be shown on these pages. 

Added tests to verify correctness of data coming out of the Selection form. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Selection" output type with configurable enumerated options and an array mode; schema and prompts now reflect selections and array semantics with a max-options limit.

* **UX / Style**
  * Interactive controls and styles for managing selection options and an array-toggle; Enter key prevented from submitting certain forms.

* **Templates**
  * Extraction views and summaries now display array and selection metadata.

* **Forms / Validation**
  * Server-side form/model validation and hidden fields enforce selection rules and array handling.

* **Tests**
  * New tests for forms, models, schema generation, and edge cases.

* **Chores**
  * Database migrations to add selection and array fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->