### PR TITLE
Allow middleware to detect locale from users browser and allow Django translations

### DIFF
--- a/radis/settings/base.py
+++ b/radis/settings/base.py
@@ -92,6 +92,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -271,7 +272,7 @@ LOGGING = {
 LANGUAGE_CODE = "en-us"
 
 # TODO: We don't want use translations yet, but everything is hardcoded in English
-USE_I18N = False
+USE_I18N = True
 
 USE_TZ = True
 


### PR DESCRIPTION
Adding LocaleMiddleware to middleware and enabling translations. 