### PR TITLE
Add a facility to copy user specific certificates to the containers

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -2,6 +2,8 @@ x-app: &default-app
   volumes:
     - ${BACKUP_DIR:?}:/backups
     - ${RADIS_CA_CERTS_DIR:-/etc/radis/certs}:/usr/local/share/ca-certificates/custom:ro
+    - ./scripts/radis-entrypoint.sh:/usr/local/bin/radis-entrypoint.sh:ro
+  entrypoint: ["/usr/local/bin/radis-entrypoint.sh"]
   depends_on:
     - postgres
   environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,10 +52,6 @@ services:
       - ${REMOTE_DEBUGGING_PORT:-5678}:5678
     command: >
       bash -c "
-        if [ -d /usr/local/share/ca-certificates/custom ] && \
-          ls /usr/local/share/ca-certificates/custom/*.crt >/dev/null 2>&1; then \
-          update-ca-certificates; \
-        fi &&
         wait-for-it -s postgres.local:5432 -t 60 && 
         ./manage.py migrate &&
         ./manage.py create_superuser &&
@@ -73,10 +69,6 @@ services:
     image: radis_dev-default_worker:latest
     command: >
       bash -c "
-        if [ -d /usr/local/share/ca-certificates/custom ] && \
-          ls /usr/local/share/ca-certificates/custom/*.crt >/dev/null 2>&1; then \
-          update-ca-certificates; \
-        fi &&
         wait-for-it -s postgres.local:5432 -t 60 &&
         ./manage.py bg_worker -l debug -q default --autoreload
       "
@@ -86,10 +78,6 @@ services:
     image: radis_dev-llm_worker:latest
     command: >
       bash -c "
-        if [ -d /usr/local/share/ca-certificates/custom ] && \
-          ls /usr/local/share/ca-certificates/custom/*.crt >/dev/null 2>&1; then \
-          update-ca-certificates; \
-        fi &&
         wait-for-it -s postgres.local:5432 -t 60 &&
         ./manage.py bg_worker -l debug -q llm --autoreload
       "

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,10 +26,6 @@ services:
     hostname: init.local
     command: >
       bash -c "
-        if [ -d /usr/local/share/ca-certificates/custom ] && \\
-          ls /usr/local/share/ca-certificates/custom/*.crt >/dev/null 2>&1; then \\
-          update-ca-certificates; \\
-        fi &&
         wait-for-it -s postgres.local:5432 -t 120 && 
         ./manage.py migrate &&
         ./manage.py collectstatic --no-input &&
@@ -49,10 +45,6 @@ services:
       - ${WEB_HTTPS_PORT:-443}:443
     command: >
       bash -c "
-        if [ -d /usr/local/share/ca-certificates/custom ] && \\
-          ls /usr/local/share/ca-certificates/custom/*.crt >/dev/null 2>&1; then \\
-          update-ca-certificates; \\
-        fi &&
         wait-for-it -s init.local:8000 -t 300 &&
         echo 'Starting web server ...' &&
         daphne -b 0.0.0.0 -p 80 \\
@@ -69,10 +61,6 @@ services:
     <<: *default-app
     command: >
       bash -c "
-        if [ -d /usr/local/share/ca-certificates/custom ] && \\
-          ls /usr/local/share/ca-certificates/custom/*.crt >/dev/null 2>&1; then \\
-          update-ca-certificates; \\
-        fi &&
         wait-for-it -s postgres.local:5432 -t 60 &&
         ./manage.py bg_worker -q default
       "
@@ -83,10 +71,6 @@ services:
     <<: *default-app
     command: >
       bash -c "
-        if [ -d /usr/local/share/ca-certificates/custom ] && \\
-          ls /usr/local/share/ca-certificates/custom/*.crt >/dev/null 2>&1; then \\
-          update-ca-certificates; \\
-        fi &&
         wait-for-it -s postgres.local:5432 -t 60 &&
         ./manage.py bg_worker -q llm
       "

--- a/scripts/radis-entrypoint.sh
+++ b/scripts/radis-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if find /usr/local/share/ca-certificates/custom -maxdepth 1 -name '*.crt' -print -quit | \
+  grep -q .; then
+  update-ca-certificates
+fi
+
+if [ "$#" -eq 0 ]; then
+  exit 0
+fi
+
+exec "$@"


### PR DESCRIPTION
We need to trust a non publicly issued and trusted authority. So we have to install the certificates ourselves in the container. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom CA certificate support: Users can now configure a directory containing trusted TLS certificates that will be automatically processed and installed when containers start, enabling secure connections with internal certificate authorities.

* **Documentation**
  * Added comprehensive documentation on custom CA certificate configuration, including step-by-step setup instructions, certificate chain requirements, and important deployment notes for Docker Swarm environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->