### PR TITLE
Fixed the mkdocs deployment issue 

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - mkdocs_deployment_fix
 permissions:
   contents: write
 


### PR DESCRIPTION
- Set `contents: write` permission so `mkdocs gh-deploy` can push to the `gh-pages` branch
- Use `--only-group docs --no-install-project` in `uv sync` to install only documentation dependencies, avoiding unnecessary installation of the full project and its dependencies
- Use `--no-sync` in `uv run` to skip redundant dependency resolution since dependencies are already synced in the previous step



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow reliability by adding an additional branch trigger for deployments.
  * Enhanced security by tightening CI permissions to the minimum required.
  * Updated documentation dependency installation to avoid unnecessary project installs during site builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->