### PR TITLE
Skip Claude code review for Renovate bot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip for Renovate bot PRs
+    if: github.event.pull_request.user.login != 'renovate[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Add `if: github.event.pull_request.user.login != 'renovate[bot]'` condition to skip the claude-review job for Renovate bot PRs
- Remove unused commented-out filter examples
- Prevents unnecessary review status checks on automated dependency update PRs

Uses `github.event.pull_request.user.login` for precise checking of the PR author.

## Test plan
- [ ] Verify the workflow skips when a Renovate bot PR is opened
- [ ] Verify the workflow still runs for regular PRs

🤖 Generated with [Claude Code](https://claude.ai/code)