### PR TITLE
Make Postgres wait timeout configurable

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,7 +52,7 @@ services:
       - ${REMOTE_DEBUGGING_PORT:-5678}:5678
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 60 && 
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py migrate &&
         ./manage.py create_superuser &&
         ./manage.py create_example_users &&
@@ -69,7 +69,7 @@ services:
     image: radis_dev-default_worker:latest
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 60 &&
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py bg_worker -l debug -q default --autoreload
       "
 
@@ -78,7 +78,7 @@ services:
     image: radis_dev-llm_worker:latest
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 60 &&
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py bg_worker -l debug -q llm --autoreload
       "
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,7 +26,7 @@ services:
     hostname: init.local
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 120 && 
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py migrate &&
         ./manage.py collectstatic --no-input &&
         ./manage.py create_superuser &&
@@ -61,7 +61,7 @@ services:
     <<: *default-app
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 60 &&
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py bg_worker -q default
       "
     deploy:
@@ -71,7 +71,7 @@ services:
     <<: *default-app
     command: >
       bash -c "
-        wait-for-it -s postgres.local:5432 -t 60 &&
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py bg_worker -q llm
       "
     deploy:

--- a/example.env
+++ b/example.env
@@ -74,10 +74,6 @@ SSL_SERVER_CERT_FILE="./cert.pem"
 SSL_SERVER_KEY_FILE="./key.pem"
 SSL_SERVER_CHAIN_FILE="./chain.pem"
 
-# Maximum seconds to wait for PostgreSQL to become available during container startup.
-# Increase this if PostgreSQL takes longer to initialize (e.g. on low-power hardware like a NAS).
-WAIT_POSTGRES_TIMEOUT=180
-
 # The timezone used by the server.
 TIME_ZONE="Europe/Berlin"
 

--- a/example.env
+++ b/example.env
@@ -74,6 +74,10 @@ SSL_SERVER_CERT_FILE="./cert.pem"
 SSL_SERVER_KEY_FILE="./key.pem"
 SSL_SERVER_CHAIN_FILE="./chain.pem"
 
+# Maximum seconds to wait for PostgreSQL to become available during container startup.
+# Increase this if PostgreSQL takes longer to initialize (e.g. on low-power hardware like a NAS).
+WAIT_POSTGRES_TIMEOUT=180
+
 # The timezone used by the server.
 TIME_ZONE="Europe/Berlin"
 


### PR DESCRIPTION
## Summary

- Replace hard-coded `wait-for-it` timeouts with a configurable `WAIT_POSTGRES_TIMEOUT` environment variable across all docker-compose files
- Default is 180 seconds (up from 120s in prod, 60s in dev), which gives slower hardware comfortable headroom
- Users can override via `.env` without modifying compose files

Closes #212

## Test plan

- [ ] Verify `docker compose config` correctly interpolates the default (180s) when `WAIT_POSTGRES_TIMEOUT` is unset
- [ ] Verify setting `WAIT_POSTGRES_TIMEOUT=300` in `.env` overrides all `wait-for-it` calls
- [ ] Confirm containers start normally with both dev and prod compose files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configurable PostgreSQL startup timeout. The system now allows customization of the maximum wait time for PostgreSQL availability during container initialization via the `WAIT_POSTGRES_TIMEOUT` environment variable (defaults to 180 seconds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->