### PR TITLE
Add staging server deployment support

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -30,6 +30,7 @@ x-app: &default-app
     SUPPORT_EMAIL: ${SUPPORT_EMAIL:?}
     TIME_ZONE: ${TIME_ZONE:?}
     TOKEN_AUTHENTICATION_SALT: ${TOKEN_AUTHENTICATION_SALT:?}
+    STACK_NAME: ${STACK_NAME:-}
 
 services:
   init:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,5 @@
 x-app: &default-app
-  image: ghcr.io/openradx/radis:latest
+  image: ${RADIS_IMAGE:-ghcr.io/openradx/radis:latest}
   volumes:
     - web_data:/var/www/web
     - ${SSL_SERVER_CERT_FILE:?}:/etc/web/ssl/cert.pem

--- a/example.env
+++ b/example.env
@@ -17,7 +17,7 @@ WEB_HTTPS_PORT=443
 # RADIS_IMAGE=ghcr.io/openradx/radis:latest
 
 # Override the Docker Swarm stack name. Defaults to {project_name}_{environment}
-# (e.g. radis_dev, radis_prod). Also used to derive a unique session cookie name
+# (e.g. radis_dev, radis_prod). Also used to derive unique session and CSRF cookie names
 # to prevent cookie conflicts when running multiple stacks on the same host.
 # Set explicitly for additional deployments like staging.
 # STACK_NAME=radis_staging

--- a/example.env
+++ b/example.env
@@ -11,6 +11,17 @@ LLM_SERVICE_DEV_PORT=8080
 WEB_HTTP_PORT=80
 WEB_HTTPS_PORT=443
 
+# The Docker image to use for the app services.
+# Defaults to the official GHCR image. Override this to use a locally built image
+# (e.g. RADIS_IMAGE=radis-staging:latest for a staging deployment).
+# RADIS_IMAGE=ghcr.io/openradx/radis:latest
+
+# Override the Docker Swarm stack name. Defaults to {project_name}_{environment}
+# (e.g. radis_dev, radis_prod). Also used to derive a unique session cookie name
+# to prevent cookie conflicts when running multiple stacks on the same host.
+# Set explicitly for additional deployments like staging.
+# STACK_NAME=radis_staging
+
 # Django debug settings (only used in development).
 FORCE_DEBUG_TOOLBAR=true
 REMOTE_DEBUGGING_ENABLED=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
 dependencies = [
-    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.20.0",
+    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.21.0",
     "adrf>=0.1.9",
     "aiofiles>=24.1.0",
     "asyncinotify>=4.2.0",

--- a/radis/settings/base.py
+++ b/radis/settings/base.py
@@ -46,6 +46,9 @@ ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS")
 
 CSRF_TRUSTED_ORIGINS = env.list("DJANGO_CSRF_TRUSTED_ORIGINS")
 
+_stack_name = env.str("STACK_NAME", default="")
+SESSION_COOKIE_NAME = f"sessionid_{_stack_name}" if _stack_name else "sessionid"
+
 INSTALLED_APPS = [
     "daphne",
     "whitenoise.runserver_nostatic",

--- a/radis/settings/base.py
+++ b/radis/settings/base.py
@@ -48,6 +48,7 @@ CSRF_TRUSTED_ORIGINS = env.list("DJANGO_CSRF_TRUSTED_ORIGINS")
 
 _stack_name = env.str("STACK_NAME", default="")
 SESSION_COOKIE_NAME = f"sessionid_{_stack_name}" if _stack_name else "sessionid"
+CSRF_COOKIE_NAME = f"csrftoken_{_stack_name}" if _stack_name else "csrftoken"
 
 INSTALLED_APPS = [
     "daphne",

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ constraints = [{ name = "autobahn", specifier = "<25.11.1" }]
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.20.0#bd890355a6d78b6015cead0fb82c15ea12d03d2c" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.21.0#f27d2f03c186703765409ae83baae126108dd0ec" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },
@@ -2824,7 +2824,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.20.0" },
+    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.21.0" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },


### PR DESCRIPTION
## Summary
- Make the Docker image configurable via `RADIS_IMAGE` env var so staging can use a locally built image instead of the GHCR release
- Add `STACK_NAME` env var to derive a unique `SESSION_COOKIE_NAME`, preventing cookie conflicts when running multiple stacks (e.g. staging + production) on the same host
- Pass `STACK_NAME` through docker-compose to the Django app
- Document both new variables in `example.env`

## Test plan
- [ ] Verify default behavior is unchanged (no `STACK_NAME` or `RADIS_IMAGE` set)
- [ ] Set `STACK_NAME=radis_staging` and confirm the session cookie is named `sessionid_radis_staging`
- [ ] Set `RADIS_IMAGE=radis-staging:latest` and confirm docker-compose uses that image
- [ ] Run staging and production stacks on the same host and verify no session cookie conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support running multiple stacks on the same host via a configurable STACK_NAME, producing stack-specific session and CSRF cookie names.
  * Option to customize the deployed container image via a RADIS_IMAGE setting.

* **Chores**
  * Updated compose and example environment templates to expose the new options.
  * Bumped a shared dependency to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->