### PR TITLE
Cap OTLP exporter retry deadline to prevent shutdown SIGKILLs

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -33,6 +33,13 @@ x-observability-env: &observability-env
   # Swarm interpolates {{.Task.Slot}} to the replica ordinal (1, 2, 3…); plain
   # `docker compose up` passes the literal through, which telemetry.py drops.
   TASK_SLOT: "{{.Task.Slot}}"
+  # Cap OTLP HTTP exporter retry deadline at 2 seconds. The default is 10s
+  # with exponential backoff, which previously exceeded Docker's 10s
+  # stop-grace-period during redeploys: when otel-collector was shut down
+  # before the apps, the OTel batch processors blocked on flush() trying
+  # to reach an unreachable collector, causing apps to be SIGKILLed
+  # (exit 137) instead of shutting down cleanly.
+  OTEL_EXPORTER_OTLP_TIMEOUT: ${OTEL_EXPORTER_OTLP_TIMEOUT:-2}
 
 networks:
   openradx-observability:


### PR DESCRIPTION
## Summary

- Set `OTEL_EXPORTER_OTLP_TIMEOUT=2` in `docker-compose.override.yml.example`
- Prevents init/web/worker containers from being SIGKILLed (exit 137) on redeploy

## Background

While auditing crashed containers on the openradx host, several exit-137 RADIS containers (`radis_prod_init`, etc.) all ended with the same OpenTelemetry exporter traceback in their final log lines:

```
requests.exceptions.ConnectionError: HTTPConnectionPool(host='otel-collector.local', port=4318):
  Max retries exceeded with url: /v1/logs
```

When `otel-collector` is shut down before the apps during a stack redeploy, the OTel batch processors call `force_flush()` on shutdown, the underlying `OTLPLogExporter` retries with exponential backoff up to its default 10-second deadline, and the worker can't reach its own SIGTERM handler in time. Docker's default 10s `stop_grace_period` expires and the container is SIGKILLed.

The 2s cap bounds the retry deadline at [`opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py:187`](https://github.com/open-telemetry/opentelemetry-python/blob/main/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/_log_exporter/__init__.py) so the flush gives up well within the grace period.

The matching change for ADIT is openradx/adit#344.

## Test plan

- [ ] After next swarm redeploy, confirm no exit-137 containers in `docker ps -a --filter status=exited` for `radis_*` services
- [ ] Logs of a deliberately-killed app no longer end with the OTLP `Max retries exceeded` traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)