### PR TITLE
Drop redundant `from __future__ import annotations`

### DIFF
--- a/radis/pgsearch/utils/indexing.py
+++ b/radis/pgsearch/utils/indexing.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from collections.abc import Iterable
 


### PR DESCRIPTION
Removes the lone `from __future__ import annotations` in the codebase for consistency (we're standardizing on *not* using PEP 563 — 3.14's PEP 649 makes forward refs work natively anyway).

`radis/pgsearch/utils/indexing.py` only has simple, non-forward-ref annotations, so the import was redundant. The module imports cleanly; `cli lint` (ruff, pyright, djlint) and all pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
