### PR TITLE
Add test coverage, fix surfaced bugs, and fail tests on warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   ci:
     runs-on: "ubuntu-latest"
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(linen
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 markers = ["acceptance: mark a test as an acceptance test."]
 filterwarnings = [
+    # Fail on any warning not explicitly ignored below
+    "error",
     # We already fixed this, so we only need to remove this ignore with next major version of factory boy
     "ignore:.*Factory._after_postgeneration will stop saving the instance:DeprecationWarning",
     'ignore:.*use of fork\(\) may lead to deadlocks.*:DeprecationWarning',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.23.0",
+    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.25.0",
     "adrf>=0.1.9",
     "aiofiles>=24.1.0",
     "asyncinotify>=4.2.0",
@@ -65,7 +65,6 @@ dev = [
     "Faker>=36.1.1",
     "ipykernel>=6.29.5",
     "ipython>=8.32.0",
-    "nest-asyncio2>=1.7.2",
     "pre-commit>=4.0.0",
     "pydicom>=2.4.4",
     "pyright>=1.1.402",

--- a/radis-client/tests/test_client_contract.py
+++ b/radis-client/tests/test_client_contract.py
@@ -1,0 +1,287 @@
+"""Contract tests for ``radis_client.RadisClient`` against the live API.
+
+The repo ships only two thin client tests. These pin the request/response
+*shapes* of every public ``RadisClient`` method against a real RADIS server
+(``live_server``) so that a wire-format change on either side (client
+``to_dict`` serialization or DRF ``ReportSerializer`` representation) is caught.
+
+Run with the test settings -- under ``radis.settings.development`` the DRF
+browsable-API renderer pulls in the debug toolbar and the live server 500s on a
+missing ``djdt`` namespace::
+
+    DJANGO_SETTINGS_MODULE=radis.settings.test uv run pytest \
+        radis-client/tests/test_client_contract.py
+
+The on-commit handlers that push reports into the external full-text search DB
+are stubbed out (that DB is not available in tests).
+"""
+
+from datetime import date, datetime
+
+import pytest
+import requests
+from pytest_django.live_server_helper import LiveServer
+from pytest_mock import MockerFixture
+from radis_client.client import RadisClient, ReportData
+from radis_client.utils.testing_helpers import (
+    create_admin_with_group_and_token,
+    create_report_data,
+)
+
+from radis.reports.models import Group, Report
+
+
+@pytest.fixture(autouse=True)
+def _stub_search_handlers(mocker: MockerFixture):
+    """Created/updated/deleted reports must not be pushed to an external FTS DB."""
+    mocker.patch("radis.reports.api.viewsets.reports_created_handlers", [])
+    mocker.patch("radis.reports.api.viewsets.reports_updated_handlers", [])
+    mocker.patch("radis.reports.api.viewsets.reports_deleted_handlers", [])
+
+
+@pytest.fixture
+def client(live_server: LiveServer) -> RadisClient:
+    _user, _group, token = create_admin_with_group_and_token()
+    return RadisClient(live_server.url, token)
+
+
+# --------------------------------------------------------------------------- #
+# ReportData.to_dict serialization contract
+# --------------------------------------------------------------------------- #
+
+
+def test_report_data_to_dict_serializes_dates_and_keeps_shapes():
+    """``to_dict`` must ISO-format the date/datetime fields and leave the nested
+    collections in the flat wire shape the API expects."""
+    rd = ReportData(
+        document_id="C-1",
+        language="en",
+        groups=[7],
+        pacs_aet="synapse",
+        pacs_name="Synapse",
+        pacs_link="http://x/1",
+        patient_id="1",
+        patient_birth_date=date(1976, 5, 23),
+        patient_sex="M",
+        study_description="CT Thorax",
+        study_datetime=datetime(2000, 8, 10, 11, 37),
+        study_instance_uid="1.2.3",
+        accession_number="42",
+        modalities=["CT", "PET"],
+        metadata={"a": "b"},
+        body="report",
+    )
+
+    data = rd.to_dict()
+
+    assert data["patient_birth_date"] == "1976-05-23"
+    assert data["study_datetime"] == "2000-08-10T11:37:00"
+    assert data["language"] == "en"  # plain string, not nested
+    assert data["modalities"] == ["CT", "PET"]  # list of codes
+    assert data["metadata"] == {"a": "b"}  # flat dict
+    assert data["groups"] == [7]
+
+
+# --------------------------------------------------------------------------- #
+# create_report
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_create_report_response_contract(client: RadisClient):
+    report_data = create_report_data()
+
+    response = client.create_report(report_data)
+
+    # Response is the flat wire representation, not the nested input shape.
+    assert response["document_id"] == report_data.document_id
+    assert response["language"] == "en"
+    assert response["metadata"] == report_data.metadata
+    assert sorted(response["modalities"]) == sorted(report_data.modalities)
+    assert response["groups"] == report_data.groups
+    assert response["body"] == report_data.body
+    # Server-derived/managed fields are present.
+    assert "id" in response
+    assert "patient_age" in response
+    assert "created_at" in response and "updated_at" in response
+    # patient_birth_date round-trips as an ISO date string.
+    assert response["patient_birth_date"] == "1976-05-23"
+
+    # And the report really exists server-side.
+    assert Report.objects.filter(document_id=report_data.document_id).exists()
+
+
+# --------------------------------------------------------------------------- #
+# retrieve_report
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_retrieve_report_round_trips(client: RadisClient):
+    report_data = create_report_data()
+    client.create_report(report_data)
+
+    retrieved = client.retrieve_report(report_data.document_id)
+
+    assert retrieved["document_id"] == report_data.document_id
+    assert retrieved["language"] == "en"
+    assert retrieved["metadata"] == report_data.metadata
+    assert sorted(retrieved["modalities"]) == sorted(report_data.modalities)
+
+
+@pytest.mark.django_db
+def test_retrieve_report_full_includes_documents_key(client: RadisClient):
+    """``full=True`` triggers the document-fetcher branch and adds a
+    ``documents`` mapping (empty when no fetchers are registered)."""
+    report_data = create_report_data()
+    client.create_report(report_data)
+
+    retrieved = client.retrieve_report(report_data.document_id, full=True)
+
+    assert "documents" in retrieved
+    assert isinstance(retrieved["documents"], dict)
+
+
+@pytest.mark.django_db
+def test_retrieve_missing_report_raises_http_error(client: RadisClient):
+    with pytest.raises(requests.HTTPError) as exc:
+        client.retrieve_report("does-not-exist")
+    assert exc.value.response is not None
+    assert exc.value.response.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# update_report  (PUT, with and without upsert)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_update_existing_report_returns_updated_body(client: RadisClient):
+    report_data = create_report_data()
+    client.create_report(report_data)
+
+    report_data.body = "Updated findings via client"
+    response = client.update_report(report_data.document_id, report_data)
+
+    assert response["body"] == "Updated findings via client"
+    assert response["document_id"] == report_data.document_id
+    assert Report.objects.get(document_id=report_data.document_id).body == (
+        "Updated findings via client"
+    )
+
+
+@pytest.mark.django_db
+def test_update_missing_without_upsert_raises_404(client: RadisClient):
+    report_data = create_report_data()  # never created server-side
+    with pytest.raises(requests.HTTPError) as exc:
+        client.update_report(report_data.document_id, report_data, upsert=False)
+    assert exc.value.response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_update_with_upsert_creates_missing_report(client: RadisClient):
+    report_data = create_report_data()
+
+    response = client.update_report(report_data.document_id, report_data, upsert=True)
+
+    # Upsert-create returns the created representation.
+    assert response["document_id"] == report_data.document_id
+    assert Report.objects.filter(document_id=report_data.document_id).exists()
+
+
+# --------------------------------------------------------------------------- #
+# update_reports_bulk
+# --------------------------------------------------------------------------- #
+
+
+def _bulk_report_data(document_id: str, group: Group) -> ReportData:
+    """A bulk ReportData reusing one group (``create_report_data`` makes a fresh
+    uniquely-named group on every call, which collides if used more than once)."""
+    return ReportData(
+        document_id=document_id,
+        language="en",
+        groups=[group.pk],
+        pacs_aet="synapse",
+        pacs_name="Synapse",
+        pacs_link="http://synapse.net/1",
+        patient_id="1234578",
+        patient_birth_date=date(1976, 5, 23),
+        patient_sex="M",
+        study_description="CT of the Thorax",
+        study_datetime=datetime(2000, 8, 10, 11, 37),
+        study_instance_uid="1.2.3",
+        accession_number="345348389",
+        modalities=["CT", "PET"],
+        metadata={"k": "v"},
+        body="This is the report",
+    )
+
+
+@pytest.mark.django_db
+def test_bulk_upsert_response_contract(client: RadisClient):
+    group = Group.objects.create(name="BulkGroup")
+
+    response = client.update_reports_bulk(
+        [
+            _bulk_report_data("bulk-c-1", group),
+            _bulk_report_data("bulk-c-2", group),
+        ]
+    )
+
+    # The bulk endpoint returns counters, not the report bodies.
+    assert response["created"] == 2
+    assert response["updated"] == 0
+    assert response["invalid"] == 0
+    assert Report.objects.filter(document_id__in=["bulk-c-1", "bulk-c-2"]).count() == 2
+
+
+@pytest.mark.django_db
+def test_bulk_upsert_updates_existing(client: RadisClient):
+    group = Group.objects.create(name="BulkGroup2")
+    first = _bulk_report_data("bulk-upd", group)
+    client.create_report(first)
+
+    first.body = "second pass body"
+    response = client.update_reports_bulk([first])
+
+    assert response["created"] == 0
+    assert response["updated"] == 1
+    assert Report.objects.get(document_id="bulk-upd").body == "second pass body"
+
+
+# --------------------------------------------------------------------------- #
+# delete_report
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_delete_report_returns_none_and_removes(client: RadisClient):
+    report_data = create_report_data()
+    client.create_report(report_data)
+
+    result = client.delete_report(report_data.document_id)
+
+    assert result is None
+    assert not Report.objects.filter(document_id=report_data.document_id).exists()
+
+
+@pytest.mark.django_db
+def test_delete_missing_report_raises_404(client: RadisClient):
+    with pytest.raises(requests.HTTPError) as exc:
+        client.delete_report("never-existed")
+    assert exc.value.response.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Auth contract
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_bad_token_is_rejected(live_server: LiveServer):
+    bad_client = RadisClient(live_server.url, "not-a-real-token")
+    report_data = create_report_data()
+
+    with pytest.raises(requests.HTTPError) as exc:
+        bad_client.create_report(report_data)
+    assert exc.value.response.status_code in (401, 403)

--- a/radis-client/tests/test_client_contract.py
+++ b/radis-client/tests/test_client_contract.py
@@ -175,6 +175,7 @@ def test_update_missing_without_upsert_raises_404(client: RadisClient):
     report_data = create_report_data()  # never created server-side
     with pytest.raises(requests.HTTPError) as exc:
         client.update_report(report_data.document_id, report_data, upsert=False)
+    assert exc.value.response is not None
     assert exc.value.response.status_code == 404
 
 
@@ -269,6 +270,7 @@ def test_delete_report_returns_none_and_removes(client: RadisClient):
 def test_delete_missing_report_raises_404(client: RadisClient):
     with pytest.raises(requests.HTTPError) as exc:
         client.delete_report("never-existed")
+    assert exc.value.response is not None
     assert exc.value.response.status_code == 404
 
 
@@ -284,4 +286,5 @@ def test_bad_token_is_rejected(live_server: LiveServer):
 
     with pytest.raises(requests.HTTPError) as exc:
         bad_client.create_report(report_data)
+    assert exc.value.response is not None
     assert exc.value.response.status_code in (401, 403)

--- a/radis/chats/tests/test_views.py
+++ b/radis/chats/tests/test_views.py
@@ -1,0 +1,298 @@
+"""Async tests for the chats views (the app previously had zero tests).
+
+These cover the LLM-backed flows -- chat creation (system-prompt assembly,
+title generation), multi-turn updates (history assembly via get_role_display) --
+plus ownership/permission behaviour.
+
+The async LLM is mocked at the ``openai.AsyncOpenAI`` boundary used by
+``AsyncChatClient``. The mock CAPTURES every ``chat.completions.create`` call so
+we can assert the assembled message history reaches the model. Each call returns
+a fresh awaitable (the view calls ``chat()`` more than once per request).
+"""
+
+import contextlib
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from adit_radis_shared.accounts.factories import UserFactory
+from asgiref.sync import sync_to_async
+from django.http import HttpResponse
+from django.test import AsyncClient
+from django.urls import reverse
+
+from radis.chats.models import Chat, ChatMessage, ChatRole
+from radis.reports.factories import ReportFactory
+
+HX = {"headers": {"HX-Request": "true"}}
+
+
+@contextlib.contextmanager
+def _stub_render():
+    """Neutralise template rendering for the success-path views.
+
+    The chats partials use django-template-partials includes
+    ("chats/chat.html#heading") that don't resolve under a plain unit-test
+    render. We assert on DB side effects and the captured LLM calls instead of
+    on the rendered HTML, so replace views.render with a trivial response. All
+    view logic (prompt assembly, LLM calls, persistence) still runs unchanged.
+    """
+    with patch("radis.chats.views.render", return_value=HttpResponse("ok")):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _disable_debug_toolbar(settings):
+    """The dev env (example.env) sets FORCE_DEBUG_TOOLBAR=true, which makes the
+    debug toolbar try to render on every HTML response and then fail to reverse
+    its 'djdt' URLs (not in the test URLconf). Force it off for these tests --
+    this mirrors radis.settings.test."""
+    settings.DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda request: False}
+
+
+class _AsyncCapture:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+
+def make_capturing_async_openai_mock(*contents: str) -> tuple[MagicMock, _AsyncCapture]:
+    """Fake ``openai.AsyncOpenAI``.
+
+    ``contents`` are returned in order across successive ``chat.completions.create``
+    calls (the last is reused if more calls happen). Each call yields a fresh
+    awaitable and records the request kwargs.
+    """
+    capture = _AsyncCapture()
+    responses = list(contents)
+
+    async def fake_create(**kwargs: Any) -> MagicMock:
+        capture.calls.append(kwargs)
+        idx = min(len(capture.calls) - 1, len(responses) - 1)
+        content = responses[idx]
+        return MagicMock(choices=[MagicMock(message=MagicMock(content=content))])
+
+    openai_mock = MagicMock()
+    openai_mock.chat.completions.create = fake_create
+    return openai_mock, capture
+
+
+async def _login(user) -> AsyncClient:
+    client = AsyncClient()
+    await sync_to_async(client.force_login)(user)
+    return client
+
+
+# --------------------------------------------------------------------------- #
+# chat_create_view
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_create_chat_general_prompt_persists_messages_and_title():
+    user = await sync_to_async(UserFactory.create)(is_active=True)
+    client = await _login(user)
+
+    openai_mock, capture = make_capturing_async_openai_mock("LLM answer", "Generated Title")
+    with patch("openai.AsyncOpenAI", return_value=openai_mock), _stub_render():
+        resp = await client.post(
+            reverse("chat_create"),
+            data={"prompt": "What is pneumonia?", "report_id": ""},
+            **HX,
+        )
+
+    assert resp.status_code == 200
+
+    chat = await sync_to_async(Chat.objects.get)()
+    assert chat.owner_id == user.pk
+    assert chat.report_id is None
+    # Title comes from the (stripped, punctuation-trimmed) second LLM response.
+    assert chat.title == "Generated Title"
+
+    # Three messages stored in order: SYSTEM, USER, ASSISTANT.
+    msgs = await sync_to_async(
+        lambda: list(chat.messages.order_by("id").values_list("role", "content"))
+    )()
+    assert [m[0] for m in msgs] == [ChatRole.SYSTEM, ChatRole.USER, ChatRole.ASSISTANT]
+    assert msgs[1][1] == "What is pneumonia?"
+    assert msgs[2][1] == "LLM answer"
+
+    # Two LLM calls: one for the answer, one for the title.
+    assert len(capture.calls) == 2
+    # The answer call sends the general system prompt + the user prompt.
+    from django.conf import settings
+
+    answer_messages = capture.calls[0]["messages"]
+    assert answer_messages[0]["content"] == settings.CHAT_GENERAL_SYSTEM_PROMPT
+    assert answer_messages[1]["content"] == "What is pneumonia?"
+    # The title call passes max_completion_tokens (the answer call does not).
+    assert "max_completion_tokens" not in capture.calls[0]
+    assert capture.calls[1]["max_completion_tokens"] == 20
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_create_chat_with_report_embeds_report_body_in_system_prompt():
+    user = await sync_to_async(UserFactory.create)(is_active=True)
+    report = await sync_to_async(ReportFactory.create)(body="UNIQUE-REPORT-FINDINGS-XYZ")
+    client = await _login(user)
+
+    openai_mock, capture = make_capturing_async_openai_mock("answer", "title")
+    with patch("openai.AsyncOpenAI", return_value=openai_mock), _stub_render():
+        resp = await client.post(
+            reverse("chat_create"),
+            data={"prompt": "Summarize", "report_id": str(report.pk)},
+            **HX,
+        )
+
+    assert resp.status_code == 200
+
+    chat = await sync_to_async(Chat.objects.get)()
+    assert chat.report_id == report.pk
+
+    # The report body must be substituted into the system prompt that reaches the LLM.
+    system_prompt = capture.calls[0]["messages"][0]["content"]
+    assert "UNIQUE-REPORT-FINDINGS-XYZ" in system_prompt
+
+    # And it must be persisted as the stored SYSTEM message.
+    system_msg = await sync_to_async(
+        lambda: chat.messages.get(role=ChatRole.SYSTEM).content
+    )()
+    assert "UNIQUE-REPORT-FINDINGS-XYZ" in system_msg
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_create_chat_post_without_htmx_is_rejected():
+    user = await sync_to_async(UserFactory.create)(is_active=True)
+    client = await _login(user)
+
+    openai_mock, _ = make_capturing_async_openai_mock("a", "t")
+    with patch("openai.AsyncOpenAI", return_value=openai_mock):
+        # No HX header -> SuspiciousOperation -> 400.
+        resp = await client.post(
+            reverse("chat_create"), data={"prompt": "hi", "report_id": ""}
+        )
+
+    assert resp.status_code == 400
+    assert await sync_to_async(Chat.objects.count)() == 0
+
+
+# --------------------------------------------------------------------------- #
+# chat_update_view (multi-turn history)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_update_chat_sends_full_history_and_appends_turn():
+    user = await sync_to_async(UserFactory.create)(is_active=True)
+    client = await _login(user)
+
+    # Seed a chat with an existing system/user/assistant turn.
+    chat = await sync_to_async(Chat.objects.create)(owner=user, title="t")
+    await sync_to_async(ChatMessage.objects.create)(
+        chat=chat, role=ChatRole.SYSTEM, content="SYS-PROMPT"
+    )
+    await sync_to_async(ChatMessage.objects.create)(
+        chat=chat, role=ChatRole.USER, content="first question"
+    )
+    await sync_to_async(ChatMessage.objects.create)(
+        chat=chat, role=ChatRole.ASSISTANT, content="first answer"
+    )
+
+    openai_mock, capture = make_capturing_async_openai_mock("second answer")
+    with patch("openai.AsyncOpenAI", return_value=openai_mock), _stub_render():
+        resp = await client.post(
+            reverse("chat_update", args=[chat.pk]),
+            data={"prompt": "second question"},
+            **HX,
+        )
+
+    assert resp.status_code == 200
+    assert len(capture.calls) == 1
+
+    # History is rebuilt from stored messages (roles lowercased via
+    # get_role_display) + the new user prompt -- SYSTEM is NOT excluded here.
+    sent = capture.calls[0]["messages"]
+    assert sent == [
+        {"role": "system", "content": "SYS-PROMPT"},
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+        {"role": "user", "content": "second question"},
+    ]
+
+    # The new user + assistant messages were persisted.
+    roles = await sync_to_async(
+        lambda: list(chat.messages.order_by("id").values_list("role", "content"))
+    )()
+    assert roles[-2] == (ChatRole.USER, "second question")
+    assert roles[-1] == (ChatRole.ASSISTANT, "second answer")
+
+
+# --------------------------------------------------------------------------- #
+# Ownership / permissions
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_update_chat_owned_by_other_user_is_blocked():
+    """Ownership is enforced on update: a non-owner cannot mutate the chat and
+    the LLM is never consulted.
+
+    NOTE (inconsistency, not asserted as a bug here): chat_update_view uses
+    ``Chat.objects...aget(pk=pk, owner=request.user)`` which raises
+    Chat.DoesNotExist (HTTP 500) for a non-owner, whereas chat_detail_view /
+    chat_delete_view use get_object_or_404 (HTTP 404). Consider aget_object_or_404
+    in chat_update_view for consistent 404 behaviour.
+    """
+    owner = await sync_to_async(UserFactory.create)(is_active=True)
+    other = await sync_to_async(UserFactory.create)(is_active=True)
+    chat = await sync_to_async(Chat.objects.create)(owner=owner, title="t")
+    await sync_to_async(ChatMessage.objects.create)(
+        chat=chat, role=ChatRole.SYSTEM, content="s"
+    )
+
+    client = await _login(other)
+    openai_mock, capture = make_capturing_async_openai_mock("nope")
+    with patch("openai.AsyncOpenAI", return_value=openai_mock):
+        with pytest.raises(Chat.DoesNotExist):
+            await client.post(
+                reverse("chat_update", args=[chat.pk]),
+                data={"prompt": "hello"},
+                **HX,
+            )
+
+    # The LLM must never be consulted for a chat the user does not own.
+    assert len(capture.calls) == 0
+    # No new messages were appended to the victim's chat.
+    assert await sync_to_async(chat.messages.count)() == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_detail_view_only_returns_own_chat():
+    owner = await sync_to_async(UserFactory.create)(is_active=True)
+    other = await sync_to_async(UserFactory.create)(is_active=True)
+    chat = await sync_to_async(Chat.objects.create)(owner=owner, title="t")
+
+    # Owner can read it.
+    owner_client = await _login(owner)
+    resp_owner = await owner_client.get(reverse("chat_detail", args=[chat.pk]))
+    assert resp_owner.status_code == 200
+
+    # A different user cannot.
+    other_client = await _login(other)
+    resp_other = await other_client.get(reverse("chat_detail", args=[chat.pk]))
+    assert resp_other.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_chat_list_requires_login():
+    client = AsyncClient()
+    resp = await client.get(reverse("chat_list"))
+    # LoginRequired -> redirect to login.
+    assert resp.status_code == 302
+    assert "/login" in resp.url or "next=" in resp.url

--- a/radis/chats/tests/test_views.py
+++ b/radis/chats/tests/test_views.py
@@ -24,7 +24,9 @@ from django.urls import reverse
 from radis.chats.models import Chat, ChatMessage, ChatRole
 from radis.reports.factories import ReportFactory
 
-HX = {"headers": {"HX-Request": "true"}}
+# HTMX marker header. Passed via ``headers=`` so the test client sets HTTP_HX_REQUEST,
+# which the views require (a missing header raises SuspiciousOperation -> 400).
+HX_HEADERS = {"HX-Request": "true"}
 
 
 @contextlib.contextmanager
@@ -98,14 +100,14 @@ async def test_create_chat_general_prompt_persists_messages_and_title():
         resp = await client.post(
             reverse("chat_create"),
             data={"prompt": "What is pneumonia?", "report_id": ""},
-            **HX,
+            headers=HX_HEADERS,
         )
 
     assert resp.status_code == 200
 
     chat = await sync_to_async(Chat.objects.get)()
-    assert chat.owner_id == user.pk
-    assert chat.report_id is None
+    assert await sync_to_async(lambda: chat.owner)() == user
+    assert await sync_to_async(lambda: chat.report)() is None
     # Title comes from the (stripped, punctuation-trimmed) second LLM response.
     assert chat.title == "Generated Title"
 
@@ -142,13 +144,13 @@ async def test_create_chat_with_report_embeds_report_body_in_system_prompt():
         resp = await client.post(
             reverse("chat_create"),
             data={"prompt": "Summarize", "report_id": str(report.pk)},
-            **HX,
+            headers=HX_HEADERS,
         )
 
     assert resp.status_code == 200
 
     chat = await sync_to_async(Chat.objects.get)()
-    assert chat.report_id == report.pk
+    assert await sync_to_async(lambda: chat.report)() == report
 
     # The report body must be substituted into the system prompt that reaches the LLM.
     system_prompt = capture.calls[0]["messages"][0]["content"]
@@ -206,7 +208,7 @@ async def test_update_chat_sends_full_history_and_appends_turn():
         resp = await client.post(
             reverse("chat_update", args=[chat.pk]),
             data={"prompt": "second question"},
-            **HX,
+            headers=HX_HEADERS,
         )
 
     assert resp.status_code == 200
@@ -261,7 +263,7 @@ async def test_update_chat_owned_by_other_user_is_blocked():
             await client.post(
                 reverse("chat_update", args=[chat.pk]),
                 data={"prompt": "hello"},
-                **HX,
+                headers=HX_HEADERS,
             )
 
     # The LLM must never be consulted for a chat the user does not own.
@@ -295,4 +297,5 @@ async def test_chat_list_requires_login():
     resp = await client.get(reverse("chat_list"))
     # LoginRequired -> redirect to login.
     assert resp.status_code == 302
-    assert "/login" in resp.url or "next=" in resp.url
+    location = resp["Location"]
+    assert "/login" in location or "next=" in location

--- a/radis/chats/tests/test_views.py
+++ b/radis/chats/tests/test_views.py
@@ -240,14 +240,8 @@ async def test_update_chat_sends_full_history_and_appends_turn():
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_update_chat_owned_by_other_user_is_blocked():
-    """Ownership is enforced on update: a non-owner cannot mutate the chat and
-    the LLM is never consulted.
-
-    NOTE (inconsistency, not asserted as a bug here): chat_update_view uses
-    ``Chat.objects...aget(pk=pk, owner=request.user)`` which raises
-    Chat.DoesNotExist (HTTP 500) for a non-owner, whereas chat_detail_view /
-    chat_delete_view use get_object_or_404 (HTTP 404). Consider aget_object_or_404
-    in chat_update_view for consistent 404 behaviour.
+    """Ownership is enforced on update: a non-owner gets a 404 (consistent with
+    chat_detail_view / chat_delete_view) and the LLM is never consulted.
     """
     owner = await database_sync_to_async(UserFactory.create)(is_active=True)
     other = await database_sync_to_async(UserFactory.create)(is_active=True)
@@ -259,12 +253,12 @@ async def test_update_chat_owned_by_other_user_is_blocked():
     client = await _login(other)
     openai_mock, capture = make_capturing_async_openai_mock("nope")
     with patch("openai.AsyncOpenAI", return_value=openai_mock):
-        with pytest.raises(Chat.DoesNotExist):
-            await client.post(
-                reverse("chat_update", args=[chat.pk]),
-                data={"prompt": "hello"},
-                headers=HX_HEADERS,
-            )
+        response = await client.post(
+            reverse("chat_update", args=[chat.pk]),
+            data={"prompt": "hello"},
+            headers=HX_HEADERS,
+        )
+    assert response.status_code == 404
 
     # The LLM must never be consulted for a chat the user does not own.
     assert len(capture.calls) == 0

--- a/radis/chats/tests/test_views.py
+++ b/radis/chats/tests/test_views.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from adit_radis_shared.accounts.factories import UserFactory
-from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
 from django.http import HttpResponse
 from django.test import AsyncClient
 from django.urls import reverse
@@ -80,7 +80,7 @@ def make_capturing_async_openai_mock(*contents: str) -> tuple[MagicMock, _AsyncC
 
 async def _login(user) -> AsyncClient:
     client = AsyncClient()
-    await sync_to_async(client.force_login)(user)
+    await database_sync_to_async(client.force_login)(user)
     return client
 
 
@@ -92,7 +92,7 @@ async def _login(user) -> AsyncClient:
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_create_chat_general_prompt_persists_messages_and_title():
-    user = await sync_to_async(UserFactory.create)(is_active=True)
+    user = await database_sync_to_async(UserFactory.create)(is_active=True)
     client = await _login(user)
 
     openai_mock, capture = make_capturing_async_openai_mock("LLM answer", "Generated Title")
@@ -105,14 +105,14 @@ async def test_create_chat_general_prompt_persists_messages_and_title():
 
     assert resp.status_code == 200
 
-    chat = await sync_to_async(Chat.objects.get)()
-    assert await sync_to_async(lambda: chat.owner)() == user
-    assert await sync_to_async(lambda: chat.report)() is None
+    chat = await database_sync_to_async(Chat.objects.get)()
+    assert await database_sync_to_async(lambda: chat.owner)() == user
+    assert await database_sync_to_async(lambda: chat.report)() is None
     # Title comes from the (stripped, punctuation-trimmed) second LLM response.
     assert chat.title == "Generated Title"
 
     # Three messages stored in order: SYSTEM, USER, ASSISTANT.
-    msgs = await sync_to_async(
+    msgs = await database_sync_to_async(
         lambda: list(chat.messages.order_by("id").values_list("role", "content"))
     )()
     assert [m[0] for m in msgs] == [ChatRole.SYSTEM, ChatRole.USER, ChatRole.ASSISTANT]
@@ -135,8 +135,8 @@ async def test_create_chat_general_prompt_persists_messages_and_title():
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_create_chat_with_report_embeds_report_body_in_system_prompt():
-    user = await sync_to_async(UserFactory.create)(is_active=True)
-    report = await sync_to_async(ReportFactory.create)(body="UNIQUE-REPORT-FINDINGS-XYZ")
+    user = await database_sync_to_async(UserFactory.create)(is_active=True)
+    report = await database_sync_to_async(ReportFactory.create)(body="UNIQUE-REPORT-FINDINGS-XYZ")
     client = await _login(user)
 
     openai_mock, capture = make_capturing_async_openai_mock("answer", "title")
@@ -149,15 +149,15 @@ async def test_create_chat_with_report_embeds_report_body_in_system_prompt():
 
     assert resp.status_code == 200
 
-    chat = await sync_to_async(Chat.objects.get)()
-    assert await sync_to_async(lambda: chat.report)() == report
+    chat = await database_sync_to_async(Chat.objects.get)()
+    assert await database_sync_to_async(lambda: chat.report)() == report
 
     # The report body must be substituted into the system prompt that reaches the LLM.
     system_prompt = capture.calls[0]["messages"][0]["content"]
     assert "UNIQUE-REPORT-FINDINGS-XYZ" in system_prompt
 
     # And it must be persisted as the stored SYSTEM message.
-    system_msg = await sync_to_async(
+    system_msg = await database_sync_to_async(
         lambda: chat.messages.get(role=ChatRole.SYSTEM).content
     )()
     assert "UNIQUE-REPORT-FINDINGS-XYZ" in system_msg
@@ -166,7 +166,7 @@ async def test_create_chat_with_report_embeds_report_body_in_system_prompt():
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_create_chat_post_without_htmx_is_rejected():
-    user = await sync_to_async(UserFactory.create)(is_active=True)
+    user = await database_sync_to_async(UserFactory.create)(is_active=True)
     client = await _login(user)
 
     openai_mock, _ = make_capturing_async_openai_mock("a", "t")
@@ -177,7 +177,7 @@ async def test_create_chat_post_without_htmx_is_rejected():
         )
 
     assert resp.status_code == 400
-    assert await sync_to_async(Chat.objects.count)() == 0
+    assert await database_sync_to_async(Chat.objects.count)() == 0
 
 
 # --------------------------------------------------------------------------- #
@@ -188,18 +188,18 @@ async def test_create_chat_post_without_htmx_is_rejected():
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_update_chat_sends_full_history_and_appends_turn():
-    user = await sync_to_async(UserFactory.create)(is_active=True)
+    user = await database_sync_to_async(UserFactory.create)(is_active=True)
     client = await _login(user)
 
     # Seed a chat with an existing system/user/assistant turn.
-    chat = await sync_to_async(Chat.objects.create)(owner=user, title="t")
-    await sync_to_async(ChatMessage.objects.create)(
+    chat = await database_sync_to_async(Chat.objects.create)(owner=user, title="t")
+    await database_sync_to_async(ChatMessage.objects.create)(
         chat=chat, role=ChatRole.SYSTEM, content="SYS-PROMPT"
     )
-    await sync_to_async(ChatMessage.objects.create)(
+    await database_sync_to_async(ChatMessage.objects.create)(
         chat=chat, role=ChatRole.USER, content="first question"
     )
-    await sync_to_async(ChatMessage.objects.create)(
+    await database_sync_to_async(ChatMessage.objects.create)(
         chat=chat, role=ChatRole.ASSISTANT, content="first answer"
     )
 
@@ -225,7 +225,7 @@ async def test_update_chat_sends_full_history_and_appends_turn():
     ]
 
     # The new user + assistant messages were persisted.
-    roles = await sync_to_async(
+    roles = await database_sync_to_async(
         lambda: list(chat.messages.order_by("id").values_list("role", "content"))
     )()
     assert roles[-2] == (ChatRole.USER, "second question")
@@ -249,10 +249,10 @@ async def test_update_chat_owned_by_other_user_is_blocked():
     chat_delete_view use get_object_or_404 (HTTP 404). Consider aget_object_or_404
     in chat_update_view for consistent 404 behaviour.
     """
-    owner = await sync_to_async(UserFactory.create)(is_active=True)
-    other = await sync_to_async(UserFactory.create)(is_active=True)
-    chat = await sync_to_async(Chat.objects.create)(owner=owner, title="t")
-    await sync_to_async(ChatMessage.objects.create)(
+    owner = await database_sync_to_async(UserFactory.create)(is_active=True)
+    other = await database_sync_to_async(UserFactory.create)(is_active=True)
+    chat = await database_sync_to_async(Chat.objects.create)(owner=owner, title="t")
+    await database_sync_to_async(ChatMessage.objects.create)(
         chat=chat, role=ChatRole.SYSTEM, content="s"
     )
 
@@ -269,15 +269,15 @@ async def test_update_chat_owned_by_other_user_is_blocked():
     # The LLM must never be consulted for a chat the user does not own.
     assert len(capture.calls) == 0
     # No new messages were appended to the victim's chat.
-    assert await sync_to_async(chat.messages.count)() == 1
+    assert await database_sync_to_async(chat.messages.count)() == 1
 
 
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 async def test_detail_view_only_returns_own_chat():
-    owner = await sync_to_async(UserFactory.create)(is_active=True)
-    other = await sync_to_async(UserFactory.create)(is_active=True)
-    chat = await sync_to_async(Chat.objects.create)(owner=owner, title="t")
+    owner = await database_sync_to_async(UserFactory.create)(is_active=True)
+    other = await database_sync_to_async(UserFactory.create)(is_active=True)
+    chat = await database_sync_to_async(Chat.objects.create)(owner=owner, title="t")
 
     # Owner can read it.
     owner_client = await _login(owner)

--- a/radis/chats/views.py
+++ b/radis/chats/views.py
@@ -156,7 +156,9 @@ async def chat_update_view(request: AuthenticatedHttpRequest, pk: int) -> HttpRe
     if not request.htmx:
         raise SuspiciousOperation
 
-    chat = await Chat.objects.prefetch_related("report").aget(pk=pk, owner=request.user)
+    chat = await aget_object_or_404(
+        Chat.objects.prefetch_related("report"), pk=pk, owner=request.user
+    )
 
     form = PromptForm(request.POST)
     if form.is_valid():

--- a/radis/collections/tests/test_exporters.py
+++ b/radis/collections/tests/test_exporters.py
@@ -5,11 +5,12 @@ produced workbook with openpyxl and verify the header row plus the cell values
 of collected reports (document fields, formatted dates, modalities).
 """
 
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 
 import pytest
 from adit_radis_shared.accounts.factories import UserFactory
 from openpyxl import load_workbook
+from openpyxl.worksheet.worksheet import Worksheet
 
 from radis.collections.factories import CollectionFactory
 from radis.collections.utils.exporters import export_collection
@@ -28,11 +29,13 @@ EXPECTED_HEADER = [
 ]
 
 
-def _load_sheet(collection):
+def _load_sheet(collection) -> Worksheet:
     file = export_collection(collection)
     file.seek(0)
     wb = load_workbook(file)
-    return wb.active
+    ws = wb.active
+    assert ws is not None
+    return ws
 
 
 @pytest.mark.django_db
@@ -52,7 +55,7 @@ def test_export_report_cell_values():
         pacs_name="Test PACS",
         patient_id="PAT-12345",
         patient_birth_date=date(1980, 1, 15),
-        study_datetime=datetime(2024, 3, 15, 10, 30, tzinfo=timezone.utc),
+        study_datetime=datetime(2024, 3, 15, 10, 30, tzinfo=UTC),
         study_description="CT Thorax",
         study_instance_uid="1.2.3.4.5",
         accession_number="ACC-9999",
@@ -79,7 +82,9 @@ def test_export_report_cell_values():
     assert by_col["Study Instance UID"] == "1.2.3.4.5"
     assert by_col["Accession Number"] == "ACC-9999"
     # Modalities are joined with ", " in insertion order.
-    assert set(by_col["Modalities"].split(", ")) == {"CT", "PT"}
+    modalities = by_col["Modalities"]
+    assert isinstance(modalities, str)
+    assert set(modalities.split(", ")) == {"CT", "PT"}
     assert by_col["Content"] == "Findings: no acute abnormality."
 
 
@@ -94,7 +99,8 @@ def test_export_multiple_reports_all_present():
     ws = _load_sheet(collection)
 
     rows = list(ws.iter_rows(min_row=2, values_only=True))
-    patient_ids = {row[EXPECTED_HEADER.index("Patient ID")] for row in rows}
+    pid_col = EXPECTED_HEADER.index("Patient ID")
+    patient_ids = {str(row[pid_col]) for row in rows}
     assert patient_ids == {"PAT-AAA", "PAT-BBB"}
 
 

--- a/radis/collections/tests/test_exporters.py
+++ b/radis/collections/tests/test_exporters.py
@@ -1,0 +1,109 @@
+"""Tests for ``export_collection`` (radis/collections/utils/exporters.py).
+
+The view-level test only asserts the HTTP MIME type; here we actually open the
+produced workbook with openpyxl and verify the header row plus the cell values
+of collected reports (document fields, formatted dates, modalities).
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+from adit_radis_shared.accounts.factories import UserFactory
+from openpyxl import load_workbook
+
+from radis.collections.factories import CollectionFactory
+from radis.collections.utils.exporters import export_collection
+from radis.reports.factories import LanguageFactory, ReportFactory
+
+EXPECTED_HEADER = [
+    "PACS",
+    "Patient ID",
+    "Patient Birth Date",
+    "Study Date",
+    "Study Description",
+    "Study Instance UID",
+    "Accession Number",
+    "Modalities",
+    "Content",
+]
+
+
+def _load_sheet(collection):
+    file = export_collection(collection)
+    file.seek(0)
+    wb = load_workbook(file)
+    return wb.active
+
+
+@pytest.mark.django_db
+def test_export_header_row():
+    collection = CollectionFactory.create(owner=UserFactory.create())
+    ws = _load_sheet(collection)
+
+    header = [cell.value for cell in ws[1]]
+    assert header == EXPECTED_HEADER
+
+
+@pytest.mark.django_db
+def test_export_report_cell_values():
+    language = LanguageFactory.create(code="en")
+    report = ReportFactory.create(
+        language=language,
+        pacs_name="Test PACS",
+        patient_id="PAT-12345",
+        patient_birth_date=date(1980, 1, 15),
+        study_datetime=datetime(2024, 3, 15, 10, 30, tzinfo=timezone.utc),
+        study_description="CT Thorax",
+        study_instance_uid="1.2.3.4.5",
+        accession_number="ACC-9999",
+        body="Findings: no acute abnormality.",
+        modalities=["CT", "PT"],
+    )
+    collection = CollectionFactory.create(owner=UserFactory.create())
+    collection.reports.add(report)
+
+    ws = _load_sheet(collection)
+
+    # Exactly one data row beneath the header.
+    rows = list(ws.iter_rows(min_row=2, values_only=True))
+    assert len(rows) == 1
+    row = rows[0]
+    by_col = dict(zip(EXPECTED_HEADER, row))
+
+    assert by_col["PACS"] == "Test PACS"
+    assert by_col["Patient ID"] == "PAT-12345"
+    # Dates are formatted via SHORT_DATE_FORMAT == "m/d/Y".
+    assert by_col["Patient Birth Date"] == "01/15/1980"
+    assert by_col["Study Date"] == "03/15/2024"
+    assert by_col["Study Description"] == "CT Thorax"
+    assert by_col["Study Instance UID"] == "1.2.3.4.5"
+    assert by_col["Accession Number"] == "ACC-9999"
+    # Modalities are joined with ", " in insertion order.
+    assert set(by_col["Modalities"].split(", ")) == {"CT", "PT"}
+    assert by_col["Content"] == "Findings: no acute abnormality."
+
+
+@pytest.mark.django_db
+def test_export_multiple_reports_all_present():
+    language = LanguageFactory.create(code="en")
+    report1 = ReportFactory.create(language=language, patient_id="PAT-AAA")
+    report2 = ReportFactory.create(language=language, patient_id="PAT-BBB")
+    collection = CollectionFactory.create(owner=UserFactory.create())
+    collection.reports.add(report1, report2)
+
+    ws = _load_sheet(collection)
+
+    rows = list(ws.iter_rows(min_row=2, values_only=True))
+    patient_ids = {row[EXPECTED_HEADER.index("Patient ID")] for row in rows}
+    assert patient_ids == {"PAT-AAA", "PAT-BBB"}
+
+
+@pytest.mark.django_db
+def test_export_empty_collection_has_header_only():
+    collection = CollectionFactory.create(owner=UserFactory.create())
+    ws = _load_sheet(collection)
+
+    header = [cell.value for cell in ws[1]]
+    assert header == EXPECTED_HEADER
+    rows = list(ws.iter_rows(min_row=2, values_only=True))
+    assert rows == []

--- a/radis/conftest.py
+++ b/radis/conftest.py
@@ -1,13 +1,1 @@
-import nest_asyncio2
-
 pytest_plugins = ["adit_radis_shared.pytest_fixtures"]
-
-
-def pytest_configure():
-    # pytest-asyncio doesn't play well with pytest-playwright as
-    # pytest-playwright creates an event loop for the whole test suite and
-    # pytest-asyncio can't create an additional one then.
-    # nest_asyncio2 works around this by allowing to create nested loops.
-    # https://github.com/pytest-dev/pytest-asyncio/issues/543
-    # https://github.com/microsoft/playwright-pytest/issues/167
-    nest_asyncio2.apply()

--- a/radis/extractions/processors.py
+++ b/radis/extractions/processors.py
@@ -37,12 +37,16 @@ class ExtractionTaskProcessor(AnalysisTaskProcessor):
                 db.close_old_connections()
 
     def process_instance(self, instance: ExtractionInstance) -> None:
-        assert not instance.is_processed
-        instance.text = instance.report.body
-        self.process_output_fields(instance)
-        instance.is_processed = True
-        instance.save()
-        db.close_old_connections()
+        # Runs in a worker thread; its connection must be closed in that same
+        # thread, also when processing fails.
+        try:
+            assert not instance.is_processed
+            instance.text = instance.report.body
+            self.process_output_fields(instance)
+            instance.is_processed = True
+            instance.save()
+        finally:
+            db.close_old_connections()
 
     def process_output_fields(self, instance: ExtractionInstance) -> None:
         job = instance.task.job

--- a/radis/extractions/tests/unit/test_llm_extraction.py
+++ b/radis/extractions/tests/unit/test_llm_extraction.py
@@ -1,0 +1,286 @@
+"""Tests for the extractions LLM data-extraction plumbing.
+
+These tests mock the OpenAI client with a fake that CAPTURES the prompt and the
+requested response schema so we can assert that the report text and the
+configured output fields actually reach the model. They also cover output-field
+schema generation (incl. the unknown-type error branch), output
+parsing/persistence and job orchestration (task/instance creation).
+
+The LLM is never called for real -- ``openai.OpenAI`` is patched at the SDK
+boundary used by ``radis.chats.utils.chat_client.ChatClient``.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+from pytest_mock import MockerFixture
+
+from radis.extractions.models import (
+    ExtractionInstance,
+    ExtractionJob,
+    ExtractionTask,
+    OutputField,
+    OutputType,
+)
+from radis.extractions.processors import ExtractionTaskProcessor
+from radis.extractions.utils.processor_utils import (
+    generate_output_fields_prompt,
+    generate_output_fields_schema,
+)
+from radis.extractions.utils.testing_helpers import create_extraction_task
+
+
+class _Capture:
+    """Records every call made to ``beta.chat.completions.parse``."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+
+def make_capturing_openai_mock(output: BaseModel) -> tuple[MagicMock, _Capture]:
+    """Return a fake ``openai.OpenAI`` instance + a capture object.
+
+    The fake's ``beta.chat.completions.parse`` records the ``model``,
+    ``messages`` and ``response_format`` it was called with and returns a
+    completion whose ``choices[0].message.parsed`` is ``output``.
+    """
+    capture = _Capture()
+
+    def fake_parse(*, model: str, messages: Any, response_format: Any) -> MagicMock:
+        capture.calls.append(
+            {
+                "model": model,
+                "messages": list(messages),
+                "response_format": response_format,
+            }
+        )
+        return MagicMock(choices=[MagicMock(message=MagicMock(parsed=output))])
+
+    openai_mock = MagicMock()
+    openai_mock.beta.chat.completions.parse.side_effect = fake_parse
+    return openai_mock, capture
+
+
+# --------------------------------------------------------------------------- #
+# Schema generation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_generate_output_fields_schema_maps_each_output_type():
+    job = create_extraction_task(num_output_fields=0, num_extraction_instances=0).job
+    OutputField.objects.create(
+        job=job, name="finding", description="d", output_type=OutputType.TEXT
+    )
+    OutputField.objects.create(
+        job=job, name="size", description="d", output_type=OutputType.NUMERIC
+    )
+    OutputField.objects.create(
+        job=job, name="malignant", description="d", output_type=OutputType.BOOLEAN
+    )
+
+    Schema = generate_output_fields_schema(job.output_fields)
+    fields = Schema.model_fields
+
+    assert set(fields) == {"finding", "size", "malignant"}
+    assert fields["finding"].annotation is str
+    assert fields["malignant"].annotation is bool
+    # NUMERIC maps to ``float | int`` (a Union), so a float and an int validate.
+    instance = Schema(finding="x", size=3.5, malignant=True)
+    assert instance.size == 3.5
+    assert Schema(finding="x", size=7, malignant=False).size == 7
+    # All fields are required (``...``); omitting one is a validation error.
+    with pytest.raises(Exception):
+        Schema(finding="x")
+
+
+def test_generate_output_fields_schema_raises_on_unknown_type():
+    """The else-branch in generate_output_fields_schema must raise ValueError.
+
+    No DB needed: we feed a plain object with an output_type that is not one of
+    the known ``OutputType`` values through a tiny queryset-like shim.
+    """
+
+    class _Field:
+        name = "weird"
+        output_type = "Z"  # not TEXT/NUMERIC/BOOLEAN
+
+    class _QS:
+        def all(self):
+            return [_Field()]
+
+    with pytest.raises(ValueError, match="Unknown data type: Z"):
+        generate_output_fields_schema(_QS())
+
+
+@pytest.mark.django_db
+def test_generate_output_fields_prompt_lists_name_and_description():
+    job = create_extraction_task(num_output_fields=0, num_extraction_instances=0).job
+    OutputField.objects.create(
+        job=job, name="laterality", description="left or right", output_type=OutputType.TEXT
+    )
+    OutputField.objects.create(
+        job=job, name="effusion", description="pleural effusion present", output_type=OutputType.BOOLEAN
+    )
+
+    prompt = generate_output_fields_prompt(job.output_fields)
+
+    assert "laterality: left or right" in prompt
+    assert "effusion: pleural effusion present" in prompt
+
+
+# --------------------------------------------------------------------------- #
+# Prompt + schema actually reach the model (capturing mock)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db(transaction=True)
+def test_report_text_and_fields_reach_the_model(mocker: MockerFixture):
+    task = create_extraction_task(num_output_fields=3, num_extraction_instances=1)
+    instance = task.instances.get()
+    report_body = instance.report.body
+    field_names = list(task.job.output_fields.values_list("name", flat=True))
+    field_descriptions = list(task.job.output_fields.values_list("description", flat=True))
+
+    class Output(BaseModel):
+        # The shape does not matter for capture; persistence is asserted elsewhere.
+        dummy: str = "x"
+
+    openai_mock, capture = make_capturing_openai_mock(Output())
+    with patch("openai.OpenAI", return_value=openai_mock):
+        ExtractionTaskProcessor(task).start()
+
+    assert len(capture.calls) == 1
+    call = capture.calls[0]
+
+    # System prompt is the single message sent (role=system in ChatClient).
+    assert len(call["messages"]) == 1
+    assert call["messages"][0]["role"] == "system"
+    sent_prompt = call["messages"][0]["content"]
+
+    # The full report body must be present in the prompt.
+    assert report_body in sent_prompt
+    # Every configured output field (name + description) must be present.
+    for name in field_names:
+        assert name in sent_prompt
+    for description in field_descriptions:
+        assert description in sent_prompt
+
+    # The requested schema is the dynamically generated OutputFieldsModel and it
+    # must carry exactly the configured field names.
+    schema = call["response_format"]
+    assert issubclass(schema, BaseModel)
+    assert set(schema.model_fields) == set(field_names)
+
+
+# --------------------------------------------------------------------------- #
+# Output parsing + persistence
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db(transaction=True)
+def test_output_is_parsed_and_persisted_per_instance(mocker: MockerFixture):
+    num_instances = 4
+    task = create_extraction_task(num_output_fields=2, num_extraction_instances=num_instances)
+
+    class Output(BaseModel):
+        answer: str
+        score: int
+
+    output = Output(answer="positive", score=42)
+    openai_mock, _ = make_capturing_openai_mock(output)
+    with patch("openai.OpenAI", return_value=openai_mock):
+        ExtractionTaskProcessor(task).start()
+
+    instances = list(task.instances.all())
+    assert len(instances) == num_instances
+    for instance in instances:
+        instance.refresh_from_db()
+        assert instance.is_processed is True
+        # ``output`` column holds the model_dump of the parsed result.
+        assert instance.output == {"answer": "positive", "score": 42}
+        # ``text`` was populated from the report body before processing.
+        assert instance.text == instance.report.body
+
+    task.refresh_from_db()
+    assert task.status == ExtractionTask.Status.SUCCESS
+
+
+@pytest.mark.django_db(transaction=True)
+def test_processor_marks_task_failure_when_model_call_raises():
+    task = create_extraction_task(num_output_fields=2, num_extraction_instances=2)
+
+    openai_mock = MagicMock()
+    openai_mock.beta.chat.completions.parse.side_effect = RuntimeError("llm boom")
+    with patch("openai.OpenAI", return_value=openai_mock):
+        ExtractionTaskProcessor(task).start()
+
+    task.refresh_from_db()
+    assert task.status == ExtractionTask.Status.FAILURE
+    assert "llm boom" in (task.message or "")
+    # Instances were never marked processed.
+    assert not task.instances.filter(is_processed=True).exists()
+
+
+# --------------------------------------------------------------------------- #
+# Job / task orchestration (preparation -> task & instance creation)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_process_extraction_job_creates_tasks_and_instances_in_batches(monkeypatch, settings):
+    from adit_radis_shared.accounts.factories import GroupFactory, UserFactory
+
+    from radis.extractions import site as extraction_site
+    from radis.extractions.site import ExtractionRetrievalProvider
+    from radis.extractions.tasks import process_extraction_job
+    from radis.reports.factories import LanguageFactory, ReportFactory
+
+    # Small batch size so 5 docs -> 3 tasks (2 + 2 + 1).
+    settings.EXTRACTION_TASK_BATCH_SIZE = 2
+
+    user = UserFactory.create(is_active=True)
+    group = GroupFactory.create()
+    language = LanguageFactory.create(code="en")
+
+    job = ExtractionJob.objects.create(
+        owner=user,
+        group=group,
+        title="Batch job",
+        query="test",
+        language=language,
+        status=ExtractionJob.Status.PENDING,
+    )
+
+    doc_ids = [f"DOC-{i}" for i in range(5)]
+    for doc_id in doc_ids:
+        ReportFactory.create(document_id=doc_id)
+
+    provider = ExtractionRetrievalProvider(
+        name="dummy",
+        count=lambda _s: len(doc_ids),
+        retrieve=lambda _s: doc_ids,
+        max_results=100,
+    )
+    monkeypatch.setattr(extraction_site, "extraction_retrieval_provider", provider)
+    # Don't actually enqueue (no procrastinate).
+    monkeypatch.setattr(ExtractionTask, "delay", lambda self: None, raising=True)
+
+    process_extraction_job(int(job.pk))
+
+    job.refresh_from_db()
+    assert job.status == ExtractionJob.Status.PENDING
+
+    tasks = list(job.tasks.all())
+    assert len(tasks) == 3  # ceil(5 / 2)
+    total_instances = ExtractionInstance.objects.filter(task__job=job).count()
+    assert total_instances == 5
+    # Every created instance references one of the retrieved reports.
+    persisted_doc_ids = set(
+        ExtractionInstance.objects.filter(task__job=job).values_list(
+            "report__document_id", flat=True
+        )
+    )
+    assert persisted_doc_ids == set(doc_ids)

--- a/radis/extractions/tests/unit/test_llm_extraction.py
+++ b/radis/extractions/tests/unit/test_llm_extraction.py
@@ -10,10 +10,11 @@ The LLM is never called for real -- ``openai.OpenAI`` is patched at the SDK
 boundary used by ``radis.chats.utils.chat_client.ChatClient``.
 """
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.db.models import QuerySet
 from pydantic import BaseModel
 from pytest_mock import MockerFixture
 
@@ -88,9 +89,11 @@ def test_generate_output_fields_schema_maps_each_output_type():
     assert fields["finding"].annotation is str
     assert fields["malignant"].annotation is bool
     # NUMERIC maps to ``float | int`` (a Union), so a float and an int validate.
-    instance = Schema(finding="x", size=3.5, malignant=True)
+    # Schema is built dynamically, so its fields aren't statically known to the type
+    # checker; access them through Any-typed instances.
+    instance = cast(Any, Schema(finding="x", size=3.5, malignant=True))
     assert instance.size == 3.5
-    assert Schema(finding="x", size=7, malignant=False).size == 7
+    assert cast(Any, Schema(finding="x", size=7, malignant=False)).size == 7
     # All fields are required (``...``); omitting one is a validation error.
     with pytest.raises(Exception):
         Schema(finding="x")
@@ -112,7 +115,8 @@ def test_generate_output_fields_schema_raises_on_unknown_type():
             return [_Field()]
 
     with pytest.raises(ValueError, match="Unknown data type: Z"):
-        generate_output_fields_schema(_QS())
+        # _QS duck-types the QuerySet.all() the function calls; cast for the checker.
+        generate_output_fields_schema(cast(QuerySet[OutputField], _QS()))
 
 
 @pytest.mark.django_db
@@ -122,7 +126,10 @@ def test_generate_output_fields_prompt_lists_name_and_description():
         job=job, name="laterality", description="left or right", output_type=OutputType.TEXT
     )
     OutputField.objects.create(
-        job=job, name="effusion", description="pleural effusion present", output_type=OutputType.BOOLEAN
+        job=job,
+        name="effusion",
+        description="pleural effusion present",
+        output_type=OutputType.BOOLEAN,
     )
 
     prompt = generate_output_fields_prompt(job.output_fields)

--- a/radis/extractions/tests/unit/test_llm_extraction.py
+++ b/radis/extractions/tests/unit/test_llm_extraction.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.db.models import QuerySet
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from pytest_mock import MockerFixture
 
 from radis.extractions.models import (
@@ -95,7 +95,7 @@ def test_generate_output_fields_schema_maps_each_output_type():
     assert instance.size == 3.5
     assert cast(Any, Schema(finding="x", size=7, malignant=False)).size == 7
     # All fields are required (``...``); omitting one is a validation error.
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         Schema(finding="x")
 
 

--- a/radis/notes/tests/test_views.py
+++ b/radis/notes/tests/test_views.py
@@ -273,3 +273,146 @@ def test_note_list_view_page_size_change(client: Client):
     response = client.get(reverse("note_list") + "?per_page=50")
     assert response.status_code == 200
     assert len(response.context["notes"]) == 30
+
+
+# ---------------------------------------------------------------------------
+# Cross-user isolation on the edit/update path.
+#
+# A user must not be able to read, overwrite, or take ownership of another
+# user's note on the same report. ``NoteEditView`` keys notes by ``report_id``
+# only, so all of the assertions below probe that ownership boundary.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_note_edit_view_get_does_not_leak_other_users_note():
+    """GET on the edit dialog for a report where ONLY another user has a note
+    must not pre-fill the current user's form with the other user's text.
+
+    KNOWN BUG: ``NoteEditView.get_object`` does
+    ``Note.objects.filter(report_id=report_id).first()`` with no owner filter,
+    so the foreign note is loaded and its text rendered into the form.
+    """
+    user = UserFactory.create(is_active=True)
+    other_user = UserFactory.create(is_active=True)
+    report = create_test_report()
+    NoteFactory.create(owner=other_user, report=report, text="OTHER USERS SECRET")
+
+    client = Client()
+    client.force_login(user)
+
+    response = client.get(reverse("note_edit", args=[report.pk]), HTTP_HX_REQUEST="true")
+    assert response.status_code == 200
+    form = response.context["form"]
+    assert form.initial.get("text") in (None, ""), (
+        "edit form leaked another user's note text"
+    )
+
+
+@pytest.mark.django_db
+def test_note_edit_view_post_cannot_overwrite_other_users_note():
+    """POSTing to the edit endpoint for a report where another user owns the
+    note must NOT mutate that user's note nor steal its ownership.
+
+    KNOWN BUG (security): because ``get_object`` selects the note by report
+    only, ``form_valid`` rebinds ``owner`` to the requesting user and saves,
+    overwriting the original owner's text and hijacking the row.
+    """
+    owner = UserFactory.create(is_active=True)
+    attacker = UserFactory.create(is_active=True)
+    report = create_test_report()
+    victim_note = NoteFactory.create(owner=owner, report=report, text="Original")
+
+    client = Client()
+    client.force_login(attacker)
+
+    response = client.post(
+        reverse("note_edit", args=[report.pk]),
+        {"text": "Hijacked"},
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 204
+
+    victim_note.refresh_from_db()
+    # The victim's note must be untouched and still owned by them.
+    assert victim_note.owner_id == owner.pk, "attacker took ownership of another user's note"
+    assert victim_note.text == "Original", "attacker overwrote another user's note text"
+
+
+@pytest.mark.django_db
+def test_note_edit_view_post_creates_separate_note_per_user():
+    """Two users each editing their note on the same report should end up with
+    two distinct notes (the model allows one note per (owner, report)).
+
+    KNOWN BUG: the second user's POST loads the first user's note (report-only
+    lookup) and updates it in place instead of creating a second note, so only
+    one Note row exists afterwards.
+    """
+    user_a = UserFactory.create(is_active=True)
+    user_b = UserFactory.create(is_active=True)
+    report = create_test_report()
+    NoteFactory.create(owner=user_a, report=report, text="A's note")
+
+    client = Client()
+    client.force_login(user_b)
+    response = client.post(
+        reverse("note_edit", args=[report.pk]),
+        {"text": "B's note"},
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 204
+
+    assert Note.objects.filter(report=report).count() == 2
+    assert Note.objects.filter(owner=user_a, report=report, text="A's note").exists()
+    assert Note.objects.filter(owner=user_b, report=report, text="B's note").exists()
+
+
+@pytest.mark.django_db
+def test_note_edit_view_post_empty_text_does_not_delete_other_users_note():
+    """An attacker submitting empty text must not delete another user's note.
+
+    KNOWN BUG: ``get_object`` resolves to the foreign note (which has a pk), and
+    ``form_valid`` then deletes it because the submitted text is empty.
+    """
+    owner = UserFactory.create(is_active=True)
+    attacker = UserFactory.create(is_active=True)
+    report = create_test_report()
+    NoteFactory.create(owner=owner, report=report, text="Keep me")
+
+    client = Client()
+    client.force_login(attacker)
+    response = client.post(
+        reverse("note_edit", args=[report.pk]),
+        {"text": ""},
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 204
+
+    assert Note.objects.filter(owner=owner, report=report, text="Keep me").exists(), (
+        "attacker deleted another user's note with empty text"
+    )
+
+
+@pytest.mark.django_db
+def test_note_edit_view_post_update_own_note_when_other_user_has_one():
+    """Sanity check: when the current user already has their own note on the
+    report, editing must update THEIR note (not the other user's)."""
+    user = UserFactory.create(is_active=True)
+    other_user = UserFactory.create(is_active=True)
+    report = create_test_report()
+    own_note = NoteFactory.create(owner=user, report=report, text="Mine v1")
+    other_note = NoteFactory.create(owner=other_user, report=report, text="Theirs")
+
+    client = Client()
+    client.force_login(user)
+    response = client.post(
+        reverse("note_edit", args=[report.pk]),
+        {"text": "Mine v2"},
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 204
+
+    own_note.refresh_from_db()
+    other_note.refresh_from_db()
+    assert own_note.text == "Mine v2"
+    assert other_note.text == "Theirs"

--- a/radis/notes/tests/test_views.py
+++ b/radis/notes/tests/test_views.py
@@ -335,7 +335,7 @@ def test_note_edit_view_post_cannot_overwrite_other_users_note():
 
     victim_note.refresh_from_db()
     # The victim's note must be untouched and still owned by them.
-    assert victim_note.owner_id == owner.pk, "attacker took ownership of another user's note"
+    assert victim_note.owner == owner, "attacker took ownership of another user's note"
     assert victim_note.text == "Original", "attacker overwrote another user's note text"
 
 

--- a/radis/notes/views.py
+++ b/radis/notes/views.py
@@ -52,7 +52,7 @@ class NoteEditView(LoginRequiredMixin, HtmxOnlyMixin, UpdateView):
             queryset = self.get_queryset()
 
         report_id: int = self.kwargs["report_id"]
-        return Note.objects.filter(report_id=report_id).first()
+        return Note.objects.filter(report_id=report_id, owner=self.request.user).first()
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)

--- a/radis/pgsearch/providers.py
+++ b/radis/pgsearch/providers.py
@@ -99,7 +99,14 @@ def _build_query_string(node: QueryNode) -> str:
 
 
 def _build_filter_query(filters: SearchFilters) -> Q:
-    fq = Q()
+    # Group-scoped access control: a report is only visible to a group when its
+    # ``groups`` M2M includes that group. This mirrors the report access model
+    # used everywhere else (e.g. ``Report.objects.filter(groups=active_group)``
+    # in radis.reports.views.ReportListView/ReportDetailView and the
+    # ``groups=active_group`` lookup in radis.chats.views). ``SearchView`` always
+    # supplies ``group=active_group.pk``, so this filter is unconditional; without
+    # it the search would leak reports belonging only to other groups.
+    fq = Q(report__groups=filters.group)
 
     # Apply hard filter criteria
     if filters.patient_sex:

--- a/radis/pgsearch/providers.py
+++ b/radis/pgsearch/providers.py
@@ -1,4 +1,5 @@
 import logging
+import unicodedata
 from collections.abc import Iterator
 from typing import cast
 
@@ -26,6 +27,28 @@ def sanitize_term(term: str) -> str:
     return "".join(char for char in term if is_search_token_char(char))
 
 
+def _has_lexeme_char(term: str) -> bool:
+    """Whether ``term`` contains at least one letter, digit or mark.
+
+    Tokens made up solely of "safe" punctuation (e.g. a lone apostrophe ``'``)
+    carry no lexeme and must not be emitted into a ``to_tsquery(..., 'raw')``
+    string, where they trigger a Postgres ``ProgrammingError`` (syntax error in
+    tsquery). Real words with embedded apostrophes (``don't``, ``it's``) still
+    contain letters and are kept.
+    """
+    return any(unicodedata.category(char)[0] in ("L", "N", "M") for char in term)
+
+
+def _quote_term(term: str) -> str:
+    """Render ``term`` as a single-quoted raw-tsquery lexeme.
+
+    Embedded apostrophes are doubled so that a term like ``don't`` becomes the
+    valid lexeme ``'don''t'`` instead of prematurely closing the quote and
+    producing a tsquery syntax error.
+    """
+    return "'" + term.replace("'", "''") + "'"
+
+
 def _resolve_language(filters: SearchFilters) -> str:
     return code_to_language(filters.language)
 
@@ -33,27 +56,44 @@ def _resolve_language(filters: SearchFilters) -> str:
 def _build_query_string(node: QueryNode) -> str:
     if isinstance(node, TermNode):
         if node.term_type == "WORD":
-            return node.value
+            term = sanitize_term(node.value)
+            # A token carrying no lexeme (e.g. a lone apostrophe) must not reach
+            # the raw tsquery, where it is a syntax error; drop it to an empty
+            # query fragment that matches nothing instead of crashing.
+            if not _has_lexeme_char(term):
+                return ""
+            return _quote_term(term)
         elif node.term_type == "PHRASE":
             terms = node.value.split()
             terms = [sanitize_term(term) for term in terms]
-            terms = [term for term in terms if term]
-            terms = [f"'{term}'" for term in terms]
+            terms = [term for term in terms if _has_lexeme_char(term)]
+            terms = [_quote_term(term) for term in terms]
             return " <-> ".join(terms)
         else:
             raise ValueError(f"Unknown term type: {node.term_type}")
     elif isinstance(node, ParensNode):
-        return f"({_build_query_string(node.expression)})"
+        inner = _build_query_string(node.expression)
+        # Drop empty groups so we never emit a bare "()" into the raw tsquery.
+        return f"({inner})" if inner else ""
     elif isinstance(node, UnaryNode):
         assert node.operator == "NOT"
-        return f"!{_build_query_string(node.operand)}"
+        operand = _build_query_string(node.operand)
+        # A negation of nothing is nothing; emitting "!" alone is a syntax error.
+        return f"!{operand}" if operand else ""
     elif isinstance(node, BinaryNode):
-        if node.operator == "AND":
-            return f"{_build_query_string(node.left)} & {_build_query_string(node.right)}"
-        elif node.operator == "OR":
-            return f"{_build_query_string(node.left)} | {_build_query_string(node.right)}"
-        else:
+        if node.operator not in ("AND", "OR"):
             raise ValueError(f"Unknown operator: {node.operator}")
+        left = _build_query_string(node.left)
+        right = _build_query_string(node.right)
+        # If a side collapsed to nothing (e.g. a lone-apostrophe token was
+        # dropped), don't leave a dangling "&"/"|" operator behind -- fall back
+        # to whichever side survived (or nothing if neither did).
+        if not left:
+            return right
+        if not right:
+            return left
+        operator = "&" if node.operator == "AND" else "|"
+        return f"{left} {operator} {right}"
     else:
         raise ValueError(f"Unknown node type: {type(node)}")
 

--- a/radis/pgsearch/tests/test_providers.py
+++ b/radis/pgsearch/tests/test_providers.py
@@ -1,0 +1,367 @@
+"""DB-backed tests for the PostgreSQL full-text search provider.
+
+These exercise the real ``QueryParser`` -> ``providers.search`` -> PostgreSQL
+``to_tsquery`` path against a live database, covering:
+
+- the search-vector population side effect of saving a ``Report`` (signals),
+- plain term, phrase/proximity (``<->``) and boolean (``& | !``) operators,
+- ranking order,
+- empty / edge queries, and
+- a hostile/malformed query fed through the *real* parser to assert the
+  ``search_type="raw"`` provider does not surface an unhandled
+  ``ProgrammingError`` (HTTP 500) to the caller.
+
+All Reports are created with an explicit ``en`` language so the resolved
+PostgreSQL text-search config is deterministic (``english``); the test image
+(pgvector/pgvector:pg17) ships the ``english``, ``german`` and ``simple``
+configs.
+"""
+
+import pytest
+
+from radis.pgsearch import providers
+from radis.pgsearch.models import ReportSearchVector
+from radis.reports.factories import LanguageFactory, ReportFactory
+from radis.reports.models import Report
+from radis.search.site import Search, SearchFilters
+from radis.search.utils.query_parser import QueryNode, QueryParser, TermNode
+
+pytestmark = pytest.mark.django_db
+
+
+def make_report(body: str, *, language_code: str = "en", **overrides) -> Report:
+    """Create a ``Report`` with a deterministic language and the given body."""
+    language = LanguageFactory.create(code=language_code)
+    return ReportFactory.create(language=language, body=body, **overrides)
+
+
+def run_search(
+    raw_query: str,
+    *,
+    language: str = "en",
+    limit: int | None = 10,
+    offset: int = 0,
+) -> list[str]:
+    """Parse ``raw_query`` and run it through the provider, returning document_ids in order."""
+    node = parse(raw_query)
+    assert node is not None, f"expected a parseable query for {raw_query!r}"
+    result = providers.search(_search(node, language=language, limit=limit, offset=offset))
+    return [doc.document_id for doc in result.documents]
+
+
+def parse(raw_query: str) -> QueryNode | None:
+    node, _fixes = QueryParser().parse(raw_query)
+    return node
+
+
+def _search(
+    node: QueryNode,
+    *,
+    language: str = "en",
+    limit: int | None = 10,
+    offset: int = 0,
+) -> Search:
+    return Search(
+        query=node,
+        filters=SearchFilters(group=1, language=language),
+        offset=offset,
+        limit=limit,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Signals: saving a Report populates the search vector.
+# ---------------------------------------------------------------------------
+
+
+def test_saving_report_creates_and_populates_search_vector():
+    report = make_report("The patient has acute pneumonia in the left lung.")
+
+    search_vector = ReportSearchVector.objects.get(report=report)
+    assert search_vector.search_vector is not None
+    # lexemes are stemmed/normalised by the english config; check a stem is present
+    lexemes = str(search_vector.search_vector)
+    assert "pneumonia" in lexemes
+    assert "lung" in lexemes
+    # english stop-words are stripped out of the tsvector
+    assert "the" not in lexemes.split()
+
+
+def test_updating_report_body_refreshes_search_vector():
+    report = make_report("initial findings about pneumonia")
+
+    # Sanity: matches the original term.
+    assert run_search("pneumonia") == [report.document_id]
+
+    report.body = "revised findings about fracture"
+    report.save()
+
+    # The post_save signal re-saves the search vector with the new body.
+    assert run_search("fracture") == [report.document_id]
+    assert run_search("pneumonia") == []
+
+
+# ---------------------------------------------------------------------------
+# Plain term matching.
+# ---------------------------------------------------------------------------
+
+
+def test_plain_term_matches_only_relevant_report():
+    match = make_report("CT thorax shows pneumonia.")
+    make_report("MR knee shows a meniscus tear.")
+
+    assert run_search("pneumonia") == [match.document_id]
+
+
+def test_plain_term_is_stemmed():
+    report = make_report("The lungs show multiple opacities.")
+
+    # english stemming: "opacity" stem matches "opacities"
+    assert run_search("opacity") == [report.document_id]
+
+
+def test_plain_term_no_match_returns_empty():
+    make_report("CT thorax shows pneumonia.")
+
+    result = providers.search(_search(parse("nonexistentterm")))  # type: ignore[arg-type]
+    assert result.total_count == 0
+    assert result.documents == []
+    assert result.total_relation == "exact"
+
+
+# ---------------------------------------------------------------------------
+# Phrase / proximity (<->).
+# ---------------------------------------------------------------------------
+
+
+def test_phrase_requires_adjacent_terms_in_order():
+    adjacent = make_report("Findings consistent with pulmonary embolism today.")
+    separated = make_report("There is an embolism noted distal to the pulmonary artery.")
+
+    matched = run_search('"pulmonary embolism"')
+
+    assert adjacent.document_id in matched
+    # The phrase operator (<->) requires the words to be adjacent and ordered,
+    # so the report where the words are separated must NOT match.
+    assert separated.document_id not in matched
+
+
+def test_phrase_order_matters():
+    report = make_report("pulmonary embolism confirmed")
+
+    assert run_search('"pulmonary embolism"') == [report.document_id]
+    # reversed order is not adjacent-in-order, so no match
+    assert run_search('"embolism pulmonary"') == []
+
+
+# ---------------------------------------------------------------------------
+# Boolean operators: AND (&), OR (|), NOT (!).
+# ---------------------------------------------------------------------------
+
+
+def test_and_operator_requires_both_terms():
+    both = make_report("CT thorax shows pneumonia and effusion.")
+    only_one = make_report("CT thorax shows pneumonia, no effusion.".replace("effusion", "x"))
+
+    matched = run_search("pneumonia AND effusion")
+
+    assert both.document_id in matched
+    assert only_one.document_id not in matched
+
+
+def test_implicit_and_between_terms():
+    both = make_report("pneumonia with effusion")
+    one = make_report("pneumonia only")
+
+    # Adjacent terms without an operator are parsed as an implicit AND.
+    matched = run_search("pneumonia effusion")
+
+    assert matched == [both.document_id]
+    assert one.document_id not in matched
+
+
+def test_or_operator_matches_either_term():
+    a = make_report("isolated pneumonia")
+    b = make_report("isolated fracture")
+    neither = make_report("normal study")
+
+    matched = set(run_search("pneumonia OR fracture"))
+
+    assert matched == {a.document_id, b.document_id}
+    assert neither.document_id not in matched
+
+
+def test_not_operator_excludes_term():
+    with_effusion = make_report("pneumonia with effusion")
+    without_effusion = make_report("pneumonia without complication")
+
+    matched = run_search("pneumonia AND NOT effusion")
+
+    assert matched == [without_effusion.document_id]
+    assert with_effusion.document_id not in matched
+
+
+def test_grouping_with_parentheses():
+    target = make_report("CT thorax with pneumonia and effusion")
+    other = make_report("CT thorax with fracture and effusion")
+    excluded = make_report("CT thorax with pneumonia, no effusion".replace("effusion", "x"))
+
+    matched = set(run_search("(pneumonia OR fracture) AND effusion"))
+
+    assert matched == {target.document_id, other.document_id}
+    assert excluded.document_id not in matched
+
+
+# ---------------------------------------------------------------------------
+# Ranking order.
+# ---------------------------------------------------------------------------
+
+
+def test_results_ranked_by_relevance_descending():
+    # More occurrences of the query term -> higher ts_rank.
+    high = make_report("pneumonia pneumonia pneumonia pneumonia bilateral pneumonia")
+    low = make_report("a single mention of pneumonia among other unrelated findings here")
+
+    ordered = run_search("pneumonia")
+
+    assert ordered == [high.document_id, low.document_id]
+
+
+def test_ranking_reflects_query_specificity():
+    # Report matching both OR-terms should outrank one matching a single term.
+    both = make_report("pneumonia and fracture both clearly present")
+    single = make_report("only pneumonia present")
+
+    ordered = run_search("pneumonia OR fracture")
+
+    assert ordered[0] == both.document_id
+    assert set(ordered) == {both.document_id, single.document_id}
+
+
+# ---------------------------------------------------------------------------
+# Pagination / count semantics.
+# ---------------------------------------------------------------------------
+
+
+def test_total_count_independent_of_limit():
+    for i in range(5):
+        make_report(f"pneumonia case number {i}")
+
+    result = providers.search(_search(parse("pneumonia"), limit=2))  # type: ignore[arg-type]
+
+    assert result.total_count == 5
+    assert len(result.documents) == 2
+
+
+def test_offset_skips_leading_results():
+    reports = [make_report("pneumonia case") for _ in range(3)]
+    document_ids = {r.document_id for r in reports}
+
+    full = run_search("pneumonia", limit=None)
+    skipped = run_search("pneumonia", limit=None, offset=1)
+
+    assert set(full) == document_ids
+    assert skipped == full[1:]
+
+
+def test_count_helper_matches_search_total():
+    for i in range(3):
+        make_report(f"pneumonia variant {i}")
+    make_report("unrelated normal study")
+
+    assert providers.count(_search(parse("pneumonia"))) == 3  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Empty / edge queries.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_query_parses_to_none():
+    # A blank (or fully-stripped) query yields no AST; provider must not be called.
+    assert parse("") is None
+    assert parse("   ") is None
+    # A query consisting solely of stripped/invalid characters also collapses.
+    assert parse("***") is None
+
+
+def test_query_with_only_stopwords_matches_nothing():
+    make_report("pneumonia present")
+
+    # "the" / "and" are english stop-words; the tsquery becomes empty and
+    # therefore matches no documents (but must not error).
+    result = providers.search(_search(parse("the and")))  # type: ignore[arg-type]
+    assert result.total_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Security: hostile / malformed query strings.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw_query",
+    [
+        "pneumonia & | lung",  # dangling boolean operators
+        "& lung",  # leading operator
+        "pneumonia <->",  # dangling proximity
+        "((( unbalanced pneumonia",  # unbalanced parens
+        "a:* & !",  # tsquery weight/prefix syntax
+        "!!!",  # only negations
+        "pneumonia; DROP TABLE reports;--",  # SQL-injection shaped
+    ],
+)
+def test_hostile_query_via_parser_does_not_raise(raw_query):
+    """Malformed input routed through the real parser must not surface a 500.
+
+    The ``QueryParser`` sanitises tsquery meta-characters (``& | ! < > -`` are
+    not "search token chars") and cleans dangling operators, so these inputs
+    reach the provider as benign ASTs. This is the primary defence for the
+    ``search_type="raw"`` call and must hold.
+    """
+    make_report("The patient has pneumonia.")
+
+    node = parse(raw_query)
+    if node is None:
+        # Fully sanitised away -> nothing to search, trivially safe.
+        return
+
+    # Must not raise ProgrammingError / any DB syntax error.
+    result = providers.search(_search(node))
+    assert result.total_relation == "exact"
+
+
+@pytest.mark.parametrize("raw_query", ["'", "''", "' OR '1'='1"])
+def test_lone_apostrophe_query_does_not_raise(raw_query):
+    """A token made only of apostrophes must not crash the raw-tsquery path.
+
+    The apostrophe is in SAFE_TERM_CHARS, so such a token survives parsing, but
+    ``_build_query_string`` now drops any token that carries no letter/digit/mark
+    before it reaches ``to_tsquery(..., 'raw')``. The query therefore resolves to
+    a benign empty/no-match search instead of a ``ProgrammingError`` (HTTP 500).
+    """
+    make_report("The patient has pneumonia.")
+
+    node = parse(raw_query)
+    assert node is not None  # parser keeps apostrophes as term chars
+
+    # Must not raise ProgrammingError; the apostrophe-only token contributes no
+    # lexeme, so nothing matches the seeded report.
+    result = providers.search(_search(node))
+    assert result.total_relation == "exact"
+    assert result.documents == []
+
+
+def test_hostile_raw_termnode_reaches_db_without_crashing_when_benign():
+    """Directly crafted AST with benign content still flows to the DB safely.
+
+    This bypasses the parser to confirm the provider itself executes a single
+    real ``to_tsquery`` for a normal TermNode (the building block the security
+    cases rely on).
+    """
+    report = make_report("pneumonia confirmed")
+
+    node = TermNode("WORD", "pneumonia")
+    result = providers.search(_search(node))
+
+    assert [doc.document_id for doc in result.documents] == [report.document_id]

--- a/radis/pgsearch/tests/test_providers.py
+++ b/radis/pgsearch/tests/test_providers.py
@@ -18,6 +18,7 @@ configs.
 """
 
 import pytest
+from adit_radis_shared.accounts.factories import GroupFactory
 
 from radis.pgsearch import providers
 from radis.pgsearch.models import ReportSearchVector
@@ -29,10 +30,24 @@ from radis.search.utils.query_parser import QueryNode, QueryParser, TermNode
 pytestmark = pytest.mark.django_db
 
 
+def _search_group():
+    """The group the provider searches under (see ``_search``).
+
+    Search is group-scoped: ``providers._build_filter_query`` filters on
+    ``report__groups=filters.group``, mirroring ``Report.objects.filter(
+    groups=active_group)`` used by the report views. ``make_report`` attaches
+    this group so seeded reports are visible to the search; ``_search`` passes
+    its pk as ``SearchFilters.group``.
+    """
+    return GroupFactory.create(name="pgsearch-test-group")
+
+
 def make_report(body: str, *, language_code: str = "en", **overrides) -> Report:
-    """Create a ``Report`` with a deterministic language and the given body."""
+    """Create a ``Report`` (visible to the search group) with the given body."""
     language = LanguageFactory.create(code=language_code)
-    return ReportFactory.create(language=language, body=body, **overrides)
+    report = ReportFactory.create(language=language, body=body, **overrides)
+    report.groups.add(_search_group())
+    return report
 
 
 def run_search(
@@ -63,7 +78,7 @@ def _search(
 ) -> Search:
     return Search(
         query=node,
-        filters=SearchFilters(group=1, language=language),
+        filters=SearchFilters(group=_search_group().pk, language=language),
         offset=offset,
         limit=limit,
     )

--- a/radis/reports/api/serializers.py
+++ b/radis/reports/api/serializers.py
@@ -107,7 +107,7 @@ class ReportSerializer(serializers.ModelSerializer):
         modalities = validated_data.pop("modalities")
 
         with transaction.atomic():
-            language_instance = Language.objects.get(**language)
+            language_instance, _ = Language.objects.get_or_create(**language)
             report.language = language_instance
 
             for attr, value in validated_data.items():
@@ -133,19 +133,19 @@ class ReportSerializer(serializers.ModelSerializer):
     def to_internal_value(self, data: Any) -> Any:
         if "language" in data:
             if not isinstance(data["language"], str):
-                raise ValidationError("Invalid language type.")
+                raise ValidationError({"language": "Invalid language type."})
             data["language"] = {"code": data["language"]}
 
         if "metadata" in data:
             if not isinstance(data["metadata"], dict):
-                raise ValidationError("Invalid metadata type.")
+                raise ValidationError({"metadata": "Invalid metadata type."})
             data["metadata"] = [
                 {"key": key, "value": value} for key, value in data["metadata"].items()
             ]
 
         if "modalities" in data:
             if not isinstance(data["modalities"], list):
-                raise ValidationError("Invalid modalities type.")
+                raise ValidationError({"modalities": "Invalid modalities type."})
             data["modalities"] = [{"code": code} for code in data["modalities"]]
 
         return super().to_internal_value(data)

--- a/radis/reports/api/serializers.py
+++ b/radis/reports/api/serializers.py
@@ -131,6 +131,10 @@ class ReportSerializer(serializers.ModelSerializer):
         return report
 
     def to_internal_value(self, data: Any) -> Any:
+        if isinstance(data, dict):
+            # Don't mutate the caller's payload (it may even be an immutable QueryDict).
+            data = data.copy()
+
         if "language" in data:
             if not isinstance(data["language"], str):
                 raise ValidationError({"language": "Invalid language type."})

--- a/radis/reports/tests/test_api.py
+++ b/radis/reports/tests/test_api.py
@@ -1,0 +1,410 @@
+"""API contract tests for the reports app.
+
+These exercise the public REST contract of ``ReportViewSet`` (create, update,
+upsert-via-PUT, bulk-upsert, de-duplication, M2M/metadata handling and the
+``IsAdminUser`` authorization boundary) using DRF's ``APIClient``.
+
+The viewset registers handlers via ``transaction.on_commit`` that push reports
+into the external full-text search database. Under ``@pytest.mark.django_db``
+the surrounding transaction is rolled back and never committed, so those
+handlers do not fire. We additionally clear the handler lists in an autouse
+fixture to keep the tests independent of any site registration and safe even if
+a test opts into ``transaction=True``.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+from adit_radis_shared.accounts.factories import AdminUserFactory, GroupFactory, UserFactory
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from radis.reports.factories import LanguageFactory, ModalityFactory, ReportFactory
+from radis.reports.models import Language, Metadata, Modality, Report
+
+LIST_URL = reverse("report-list")
+BULK_UPSERT_URL = reverse("report-bulk-upsert")
+
+
+def detail_url(document_id: str) -> str:
+    return reverse("report-detail", args=[document_id])
+
+
+def make_payload(document_id: str = "doc-0001", **overrides) -> dict:
+    """A valid create/upsert payload matching the wire format the serializer expects.
+
+    ``language`` is a string, ``metadata`` a flat dict, ``modalities`` a list of
+    codes and ``groups`` a list of Group PKs (see radis_client testing helpers).
+    """
+    group = overrides.pop("group", None) or GroupFactory.create()
+    payload = {
+        "document_id": document_id,
+        "language": "en",
+        "groups": [group.pk],
+        "pacs_aet": "synapse",
+        "pacs_name": "Synapse",
+        "pacs_link": "http://synapse.example/34343",
+        "patient_id": "1234578",
+        "patient_birth_date": date(1976, 5, 23).isoformat(),
+        "patient_sex": "M",
+        "study_description": "CT of the Thorax",
+        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=timezone.utc).isoformat(),
+        "study_instance_uid": "34343-34343-34343",
+        "accession_number": "345348389",
+        "modalities": ["CT", "PT"],
+        "metadata": {
+            "series_instance_uid": "34343-676556-3343",
+            "sop_instance_uid": "35858-384834-3843",
+        },
+        "body": "This is the report",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture(autouse=True)
+def _no_report_handlers(monkeypatch):
+    """Prevent on-commit handlers (full-text search sync) from running."""
+    monkeypatch.setattr("radis.reports.api.viewsets.reports_created_handlers", [])
+    monkeypatch.setattr("radis.reports.api.viewsets.reports_updated_handlers", [])
+    monkeypatch.setattr("radis.reports.api.viewsets.reports_deleted_handlers", [])
+
+
+@pytest.fixture
+def admin_client() -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=AdminUserFactory.create())
+    return client
+
+
+@pytest.fixture
+def user_client() -> APIClient:
+    """Authenticated but non-admin (not staff)."""
+    client = APIClient()
+    client.force_authenticate(user=UserFactory.create(is_staff=False))
+    return client
+
+
+# --------------------------------------------------------------------------- #
+# Create
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_create_report(admin_client):
+    payload = make_payload(document_id="doc-create")
+
+    response = admin_client.post(LIST_URL, payload, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED
+    report = Report.objects.get(document_id="doc-create")
+    assert report.body == "This is the report"
+    assert report.patient_id == "1234578"
+    assert report.language.code == "en"
+
+
+@pytest.mark.django_db
+def test_create_report_creates_m2m_metadata_and_language(admin_client):
+    payload = make_payload(document_id="doc-m2m")
+
+    response = admin_client.post(LIST_URL, payload, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED
+    report = Report.objects.get(document_id="doc-m2m")
+
+    # language + modalities are get_or_created
+    assert Language.objects.filter(code="en").exists()
+    assert sorted(report.modality_codes) == ["CT", "PT"]
+    assert set(Modality.objects.values_list("code", flat=True)) >= {"CT", "PT"}
+
+    # metadata dict -> Metadata rows
+    metadata = {m.key: m.value for m in report.metadata.all()}
+    assert metadata == {
+        "series_instance_uid": "34343-676556-3343",
+        "sop_instance_uid": "35858-384834-3843",
+    }
+
+    # groups M2M is set from PKs
+    assert list(report.groups.values_list("pk", flat=True)) == payload["groups"]
+
+
+@pytest.mark.django_db
+def test_create_response_round_trips_representation(admin_client):
+    """to_representation must collapse language/metadata/modalities back to the
+    flat wire format (string / dict / list of codes)."""
+    payload = make_payload(document_id="doc-repr")
+
+    response = admin_client.post(LIST_URL, payload, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert data["language"] == "en"
+    assert data["metadata"] == payload["metadata"]
+    assert sorted(data["modalities"]) == ["CT", "PT"]
+
+
+@pytest.mark.django_db
+def test_create_rejects_unknown_fields(admin_client):
+    payload = make_payload(document_id="doc-unknown")
+    payload["bogus_field"] = "nope"
+
+    response = admin_client.post(LIST_URL, payload, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# --------------------------------------------------------------------------- #
+# De-duplication by document_id
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_create_duplicate_document_id_rejected(admin_client):
+    group = GroupFactory.create()
+    payload = make_payload(document_id="doc-dup", group=group)
+
+    first = admin_client.post(LIST_URL, payload, format="json")
+    assert first.status_code == status.HTTP_201_CREATED
+
+    second = admin_client.post(
+        LIST_URL, make_payload(document_id="doc-dup", group=group), format="json"
+    )
+    assert second.status_code == status.HTTP_400_BAD_REQUEST
+    assert Report.objects.filter(document_id="doc-dup").count() == 1
+
+
+# --------------------------------------------------------------------------- #
+# Update (PUT, no upsert)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_update_existing_report(admin_client):
+    LanguageFactory.create(code="en")
+    group = GroupFactory.create()
+    admin_client.post(LIST_URL, make_payload(document_id="doc-upd", group=group), format="json")
+
+    updated = make_payload(document_id="doc-upd", group=group)
+    updated["body"] = "Updated findings"
+    updated["modalities"] = ["MR"]
+    updated["metadata"] = {"new_key": "new_value"}
+
+    response = admin_client.put(detail_url("doc-upd"), updated, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    report = Report.objects.get(document_id="doc-upd")
+    assert report.body == "Updated findings"
+    assert report.modality_codes == ["MR"]
+    # update() deletes old metadata then recreates
+    assert {m.key: m.value for m in report.metadata.all()} == {"new_key": "new_value"}
+
+
+@pytest.mark.django_db
+def test_update_nonexistent_without_upsert_404(admin_client):
+    LanguageFactory.create(code="en")
+    response = admin_client.put(
+        detail_url("does-not-exist"), make_payload(document_id="does-not-exist"), format="json"
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_partial_update_not_allowed(admin_client):
+    group = GroupFactory.create()
+    admin_client.post(LIST_URL, make_payload(document_id="doc-patch", group=group), format="json")
+
+    response = admin_client.patch(detail_url("doc-patch"), {"body": "x"}, format="json")
+
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+
+# --------------------------------------------------------------------------- #
+# Upsert via PUT  (?upsert=true) -> 201 vs 200 semantics
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_upsert_put_creates_with_201(admin_client):
+    payload = make_payload(document_id="doc-upsert-new")
+
+    response = admin_client.put(
+        detail_url("doc-upsert-new") + "?upsert=true", payload, format="json"
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert Report.objects.filter(document_id="doc-upsert-new").exists()
+
+
+@pytest.mark.django_db
+def test_upsert_put_updates_existing_with_200(admin_client):
+    group = GroupFactory.create()
+    admin_client.post(
+        LIST_URL, make_payload(document_id="doc-upsert-exist", group=group), format="json"
+    )
+
+    updated = make_payload(document_id="doc-upsert-exist", group=group)
+    updated["body"] = "Upserted body"
+
+    response = admin_client.put(
+        detail_url("doc-upsert-exist") + "?upsert=true", updated, format="json"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert Report.objects.get(document_id="doc-upsert-exist").body == "Upserted body"
+    assert Report.objects.filter(document_id="doc-upsert-exist").count() == 1
+
+
+# --------------------------------------------------------------------------- #
+# bulk_upsert
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_bulk_upsert_creates_and_updates(admin_client):
+    group = GroupFactory.create()
+    # Pre-existing report that the bulk call should update (not duplicate).
+    admin_client.post(LIST_URL, make_payload(document_id="bulk-existing", group=group), format="json")
+
+    body = [
+        make_payload(document_id="bulk-existing", group=group, body="updated via bulk"),
+        make_payload(document_id="bulk-new-1", group=group),
+        make_payload(document_id="bulk-new-2", group=group),
+    ]
+
+    response = admin_client.post(BULK_UPSERT_URL, body, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["created"] == 2
+    assert data["updated"] == 1
+    assert data["invalid"] == 0
+
+    assert Report.objects.count() == 3
+    assert Report.objects.get(document_id="bulk-existing").body == "updated via bulk"
+
+
+@pytest.mark.django_db
+def test_bulk_upsert_persists_m2m_and_metadata(admin_client):
+    group = GroupFactory.create()
+    body = [make_payload(document_id="bulk-meta", group=group)]
+
+    response = admin_client.post(BULK_UPSERT_URL, body, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    report = Report.objects.get(document_id="bulk-meta")
+    assert sorted(report.modality_codes) == ["CT", "PT"]
+    assert {m.key: m.value for m in report.metadata.all()} == {
+        "series_instance_uid": "34343-676556-3343",
+        "sop_instance_uid": "35858-384834-3843",
+    }
+    assert list(report.groups.values_list("pk", flat=True)) == [group.pk]
+
+
+@pytest.mark.django_db
+def test_bulk_upsert_rewrites_metadata_and_modalities_on_update(admin_client):
+    """A second bulk upsert of the same document_id replaces its metadata and
+    modality rows rather than appending."""
+    group = GroupFactory.create()
+    admin_client.post(BULK_UPSERT_URL, [make_payload(document_id="bulk-rw", group=group)], format="json")
+
+    changed = make_payload(document_id="bulk-rw", group=group)
+    changed["modalities"] = ["US"]
+    changed["metadata"] = {"only_key": "only_value"}
+
+    response = admin_client.post(BULK_UPSERT_URL, [changed], format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["updated"] == 1
+    report = Report.objects.get(document_id="bulk-rw")
+    assert report.modality_codes == ["US"]
+    assert {m.key: m.value for m in report.metadata.all()} == {"only_key": "only_value"}
+
+
+@pytest.mark.django_db
+def test_bulk_upsert_reports_invalid_rows(admin_client):
+    group = GroupFactory.create()
+    valid = make_payload(document_id="bulk-ok", group=group)
+    invalid = make_payload(document_id="bulk-bad", group=group)
+    del invalid["body"]  # body is required
+
+    response = admin_client.post(BULK_UPSERT_URL, [valid, invalid], format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["created"] == 1
+    assert data["invalid"] == 1
+    assert "errors" in data
+    assert data["errors"][0]["document_id"] == "bulk-bad"
+    assert Report.objects.filter(document_id="bulk-ok").exists()
+    assert not Report.objects.filter(document_id="bulk-bad").exists()
+
+
+@pytest.mark.django_db
+def test_bulk_upsert_requires_list(admin_client):
+    response = admin_client.post(
+        BULK_UPSERT_URL, make_payload(document_id="not-a-list"), format="json"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# --------------------------------------------------------------------------- #
+# Authorization (IsAdminUser)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_create_rejected_for_non_admin(user_client):
+    response = user_client.post(LIST_URL, make_payload(document_id="doc-forbidden"), format="json")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert not Report.objects.filter(document_id="doc-forbidden").exists()
+
+
+@pytest.mark.django_db
+def test_create_rejected_for_anonymous():
+    client = APIClient()
+    response = client.post(LIST_URL, make_payload(document_id="doc-anon"), format="json")
+    assert response.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+    )
+    assert not Report.objects.filter(document_id="doc-anon").exists()
+
+
+@pytest.mark.django_db
+def test_bulk_upsert_rejected_for_non_admin(user_client):
+    group = GroupFactory.create()
+    response = user_client.post(
+        BULK_UPSERT_URL, [make_payload(document_id="bulk-forbidden", group=group)], format="json"
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert not Report.objects.filter(document_id="bulk-forbidden").exists()
+
+
+@pytest.mark.django_db
+def test_upsert_put_create_rejected_for_non_admin(user_client):
+    """An upsert PUT that would create a new report re-checks POST permission for
+    the cloned request; a non-admin must be refused."""
+    response = user_client.put(
+        detail_url("doc-upsert-forbidden") + "?upsert=true",
+        make_payload(document_id="doc-upsert-forbidden"),
+        format="json",
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert not Report.objects.filter(document_id="doc-upsert-forbidden").exists()
+
+
+@pytest.mark.django_db
+def test_update_rejected_for_non_admin(user_client):
+    # Seed a report directly (bypassing the API) so the PUT targets an existing object.
+    LanguageFactory.create(code="en")
+    report = ReportFactory.create(document_id="doc-upd-forbidden", modalities=["CT"])
+
+    response = user_client.put(
+        detail_url("doc-upd-forbidden"),
+        make_payload(document_id="doc-upd-forbidden"),
+        format="json",
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    report.refresh_from_db()
+    assert report.body != "This is the report"

--- a/radis/reports/tests/test_api.py
+++ b/radis/reports/tests/test_api.py
@@ -12,7 +12,7 @@ fixture to keep the tests independent of any site registration and safe even if
 a test opts into ``transaction=True``.
 """
 
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 
 import pytest
 from adit_radis_shared.accounts.factories import AdminUserFactory, GroupFactory, UserFactory
@@ -20,8 +20,8 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from radis.reports.factories import LanguageFactory, ModalityFactory, ReportFactory
-from radis.reports.models import Language, Metadata, Modality, Report
+from radis.reports.factories import LanguageFactory, ReportFactory
+from radis.reports.models import Language, Modality, Report
 
 LIST_URL = reverse("report-list")
 BULK_UPSERT_URL = reverse("report-bulk-upsert")
@@ -49,7 +49,7 @@ def make_payload(document_id: str = "doc-0001", **overrides) -> dict:
         "patient_birth_date": date(1976, 5, 23).isoformat(),
         "patient_sex": "M",
         "study_description": "CT of the Thorax",
-        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=timezone.utc).isoformat(),
+        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=UTC).isoformat(),
         "study_instance_uid": "34343-34343-34343",
         "accession_number": "345348389",
         "modalities": ["CT", "PT"],
@@ -264,7 +264,9 @@ def test_upsert_put_updates_existing_with_200(admin_client):
 def test_bulk_upsert_creates_and_updates(admin_client):
     group = GroupFactory.create()
     # Pre-existing report that the bulk call should update (not duplicate).
-    admin_client.post(LIST_URL, make_payload(document_id="bulk-existing", group=group), format="json")
+    admin_client.post(
+        LIST_URL, make_payload(document_id="bulk-existing", group=group), format="json"
+    )
 
     body = [
         make_payload(document_id="bulk-existing", group=group, body="updated via bulk"),
@@ -306,7 +308,9 @@ def test_bulk_upsert_rewrites_metadata_and_modalities_on_update(admin_client):
     """A second bulk upsert of the same document_id replaces its metadata and
     modality rows rather than appending."""
     group = GroupFactory.create()
-    admin_client.post(BULK_UPSERT_URL, [make_payload(document_id="bulk-rw", group=group)], format="json")
+    admin_client.post(
+        BULK_UPSERT_URL, [make_payload(document_id="bulk-rw", group=group)], format="json"
+    )
 
     changed = make_payload(document_id="bulk-rw", group=group)
     changed["modalities"] = ["US"]

--- a/radis/reports/tests/test_data_integrity.py
+++ b/radis/reports/tests/test_data_integrity.py
@@ -13,7 +13,7 @@ These go beyond the happy-path API contract tests in ``test_api.py`` and assert
   through rows.
 """
 
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 
 import pytest
 from adit_radis_shared.accounts.factories import AdminUserFactory, GroupFactory
@@ -52,7 +52,7 @@ def validated(document_id: str, *, group: Group, **overrides) -> dict:
         "patient_birth_date": date(1976, 5, 23),
         "patient_sex": "M",
         "study_description": "CT Thorax",
-        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=timezone.utc),
+        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=UTC),
         "study_instance_uid": "1.2.3",
         "accession_number": "345348389",
         "modalities": [{"code": "CT"}],
@@ -76,7 +76,7 @@ def make_payload(document_id: str, *, group: Group, **overrides) -> dict:
         "patient_birth_date": date(1976, 5, 23).isoformat(),
         "patient_sex": "M",
         "study_description": "CT Thorax",
-        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=timezone.utc).isoformat(),
+        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=UTC).isoformat(),
         "study_instance_uid": "1.2.3",
         "accession_number": "345348389",
         "modalities": ["CT"],
@@ -102,21 +102,28 @@ def test_document_id_is_unique_at_db_level():
 
 
 @pytest.mark.django_db
-def test_duplicate_document_id_within_one_batch_rolls_back_whole_batch():
-    """Two rows sharing a ``document_id`` in a single bulk call hit the unique
-    constraint during ``bulk_create``; the whole atomic block rolls back so no
-    report (nor any metadata) is written.
+def test_duplicate_document_id_within_one_batch_dedupes_keeping_last():
+    """Two rows sharing a ``document_id`` in a single bulk call are de-duplicated
+    by ``_bulk_upsert_reports`` (last occurrence wins) rather than hitting the
+    unique constraint during ``bulk_create``.
 
-    The viewset action does not catch this ``IntegrityError`` (it surfaces as a
-    500), but the database is left clean -- that is the property under test.
+    Upstream's bulk-upsert (#187) intentionally collapses same-``document_id``
+    rows in the payload to avoid crashing the whole batch; exactly one report is
+    written and it carries the *second* row's fields.
     """
     group = GroupFactory.create()
 
-    with pytest.raises(IntegrityError):
-        _bulk_upsert_reports([validated("dupe", group=group), validated("dupe", group=group)])
+    created, updated = _bulk_upsert_reports(
+        [
+            validated("dupe", group=group, body="first version"),
+            validated("dupe", group=group, body="second version"),
+        ]
+    )
 
-    assert Report.objects.count() == 0
-    assert Metadata.objects.count() == 0
+    assert created == ["dupe"]
+    assert updated == []
+    assert Report.objects.filter(document_id="dupe").count() == 1
+    assert Report.objects.get(document_id="dupe").body == "second version"
 
 
 # --------------------------------------------------------------------------- #
@@ -232,15 +239,15 @@ class BulkUpsertOnCommitTests(TestCase):
         assert len(callbacks) == 1
         assert created_seen == [["commit-1"]]
 
-    def test_no_handlers_fire_when_transaction_rolls_back(self):
+    def test_duplicate_in_batch_dedupes_and_fires_handler_once_on_commit(self):
         self._seed()
-        fired: list[str] = []
+        created_seen: list[list[str]] = []
 
         class _Handler:
             name = "spy"
 
             def handle(self, reports):
-                fired.append("called")
+                created_seen.append([r.document_id for r in reports])
 
         from radis.reports.api import viewsets
 
@@ -248,19 +255,23 @@ class BulkUpsertOnCommitTests(TestCase):
         viewsets.reports_created_handlers = [_Handler()]
         viewsets.reports_updated_handlers = []
 
-        # A duplicate-in-batch raises IntegrityError inside the atomic block, so
-        # the on_commit callback is discarded and the handler never fires.
-        with self.assertRaises(IntegrityError):
-            with self.captureOnCommitCallbacks(execute=True):
-                _bulk_upsert_reports(
-                    [
-                        validated("rb", group=self.group),
-                        validated("rb", group=self.group),
-                    ]
-                )
+        # A duplicate document_id in the batch is de-duplicated (last wins) instead
+        # of raising; the block commits, so the created handler fires exactly once
+        # for the single surviving report -- and only after commit.
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            created, _ = _bulk_upsert_reports(
+                [
+                    validated("rb", group=self.group, body="first version"),
+                    validated("rb", group=self.group, body="second version"),
+                ]
+            )
+            assert created == ["rb"]
+            assert created_seen == []
 
-        assert fired == []
-        assert Report.objects.filter(document_id="rb").count() == 0
+        assert len(callbacks) == 1
+        assert created_seen == [["rb"]]
+        assert Report.objects.filter(document_id="rb").count() == 1
+        assert Report.objects.get(document_id="rb").body == "second version"
 
 
 # --------------------------------------------------------------------------- #

--- a/radis/reports/tests/test_data_integrity.py
+++ b/radis/reports/tests/test_data_integrity.py
@@ -1,0 +1,333 @@
+"""Data-integrity tests for the reports bulk-upsert path and cascades.
+
+These go beyond the happy-path API contract tests in ``test_api.py`` and assert
+*transactional* and *referential* guarantees:
+
+- a partial failure inside ``_bulk_upsert_reports`` rolls the whole batch back
+  (no half-written reports / metadata / through rows),
+- the post-commit handler side effects only fire after the surrounding
+  transaction actually commits (``on_commit`` semantics),
+- ``document_id`` uniqueness is enforced at the DB level (including duplicates
+  *within* a single bulk batch), and
+- deleting a ``Report`` cascades to its ``Metadata``, search vector and M2M
+  through rows.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+from adit_radis_shared.accounts.factories import AdminUserFactory, GroupFactory
+from django.contrib.auth.models import Group
+from django.db import IntegrityError
+from django.db.utils import DataError
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from radis.pgsearch.models import ReportSearchVector
+from radis.reports.api.viewsets import _bulk_upsert_reports
+from radis.reports.factories import LanguageFactory, ModalityFactory, ReportFactory
+from radis.reports.models import Language, Metadata, Modality, Report
+
+BULK_UPSERT_URL = reverse("report-bulk-upsert")
+LIST_URL = reverse("report-list")
+
+
+def validated(document_id: str, *, group: Group, **overrides) -> dict:
+    """A validated-data dict in the shape ``_bulk_upsert_reports`` consumes.
+
+    This is the *post-serializer* nested shape: ``language`` is ``{"code": ...}``,
+    ``modalities`` a list of ``{"code": ...}``, ``metadata`` a list of
+    ``{"key", "value"}`` and ``groups`` a list of Group instances.
+    """
+    data = {
+        "document_id": document_id,
+        "language": {"code": "en"},
+        "groups": [group],
+        "pacs_aet": "synapse",
+        "pacs_name": "Synapse",
+        "pacs_link": "",
+        "patient_id": "1234578",
+        "patient_birth_date": date(1976, 5, 23),
+        "patient_sex": "M",
+        "study_description": "CT Thorax",
+        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=timezone.utc),
+        "study_instance_uid": "1.2.3",
+        "accession_number": "345348389",
+        "modalities": [{"code": "CT"}],
+        "metadata": [{"key": "k", "value": "v"}],
+        "body": "This is the report",
+    }
+    data.update(overrides)
+    return data
+
+
+def make_payload(document_id: str, *, group: Group, **overrides) -> dict:
+    """Flat wire-format payload for the HTTP API."""
+    payload = {
+        "document_id": document_id,
+        "language": "en",
+        "groups": [group.pk],
+        "pacs_aet": "synapse",
+        "pacs_name": "Synapse",
+        "pacs_link": "",
+        "patient_id": "1234578",
+        "patient_birth_date": date(1976, 5, 23).isoformat(),
+        "patient_sex": "M",
+        "study_description": "CT Thorax",
+        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=timezone.utc).isoformat(),
+        "study_instance_uid": "1.2.3",
+        "accession_number": "345348389",
+        "modalities": ["CT"],
+        "metadata": {"k": "v"},
+        "body": "This is the report",
+    }
+    payload.update(overrides)
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# document_id uniqueness
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_document_id_is_unique_at_db_level():
+    LanguageFactory.create(code="en")
+    ReportFactory.create(document_id="uniq-1", modalities=["CT"])
+
+    with pytest.raises(IntegrityError):
+        ReportFactory.create(document_id="uniq-1", modalities=["CT"])
+
+
+@pytest.mark.django_db
+def test_duplicate_document_id_within_one_batch_rolls_back_whole_batch():
+    """Two rows sharing a ``document_id`` in a single bulk call hit the unique
+    constraint during ``bulk_create``; the whole atomic block rolls back so no
+    report (nor any metadata) is written.
+
+    The viewset action does not catch this ``IntegrityError`` (it surfaces as a
+    500), but the database is left clean -- that is the property under test.
+    """
+    group = GroupFactory.create()
+
+    with pytest.raises(IntegrityError):
+        _bulk_upsert_reports([validated("dupe", group=group), validated("dupe", group=group)])
+
+    assert Report.objects.count() == 0
+    assert Metadata.objects.count() == 0
+
+
+# --------------------------------------------------------------------------- #
+# Partial-failure rollback (atomicity)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_partial_failure_rolls_back_new_reports_and_metadata():
+    """If a row in the batch violates a column constraint, ``bulk_create`` raises
+    inside the ``transaction.atomic()`` block and nothing from the batch persists
+    -- not even the valid rows that precede it.
+
+    Here the second report carries an over-length ``patient_sex`` (max_length=1),
+    which Postgres rejects at INSERT time with a ``DataError``.
+    """
+    group = GroupFactory.create()
+    good = validated("good-row", group=group)
+    bad = validated("bad-row", group=group, patient_sex="MMMM")  # exceeds max_length=1
+
+    with pytest.raises((DataError, IntegrityError)):
+        _bulk_upsert_reports([good, bad])
+
+    # No half-written state: neither the good nor the bad row, and no metadata.
+    assert not Report.objects.filter(document_id__in=["good-row", "bad-row"]).exists()
+    assert Metadata.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_metadata_failure_rolls_back_already_created_reports():
+    """A failure that occurs *after* the reports are bulk-created (during the
+    metadata write) must still roll the reports back, because the report INSERT
+    and the metadata INSERT share one ``transaction.atomic()`` block.
+
+    We force the metadata write to fail with an over-length ``value`` (the
+    ``Metadata.value`` column is ``max_length=255``).
+    """
+    group = GroupFactory.create()
+    row = validated(
+        "meta-fail",
+        group=group,
+        metadata=[{"key": "k", "value": "x" * 300}],  # exceeds value max_length=255
+    )
+
+    with pytest.raises((DataError, IntegrityError)):
+        _bulk_upsert_reports([row])
+
+    # The report was bulk-created earlier in the same atomic block but must be
+    # rolled back when the metadata insert fails.
+    assert not Report.objects.filter(document_id="meta-fail").exists()
+    assert Metadata.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_successful_bulk_upsert_persists_everything():
+    """Control: a clean batch commits reports, metadata, modalities and groups."""
+    group = GroupFactory.create()
+    created, updated = _bulk_upsert_reports(
+        [validated("ok-1", group=group), validated("ok-2", group=group)]
+    )
+
+    assert sorted(created) == ["ok-1", "ok-2"]
+    assert updated == []
+    assert Report.objects.filter(document_id__in=["ok-1", "ok-2"]).count() == 2
+    report = Report.objects.get(document_id="ok-1")
+    assert report.modality_codes == ["CT"]
+    assert {m.key: m.value for m in report.metadata.all()} == {"k": "v"}
+    assert list(report.groups.values_list("pk", flat=True)) == [group.pk]
+
+
+# --------------------------------------------------------------------------- #
+# on_commit semantics
+# --------------------------------------------------------------------------- #
+
+
+class BulkUpsertOnCommitTests(TestCase):
+    """``TestCase`` (not ``django_db``) so we can use ``captureOnCommitCallbacks``
+    to drive the ``transaction.on_commit`` hooks that the bulk path registers."""
+
+    def _seed(self):
+        self.group = GroupFactory.create()
+        self.admin = AdminUserFactory.create()
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.admin)
+
+    def test_handlers_fire_only_after_commit(self):
+        self._seed()
+        created_seen: list[list[str]] = []
+
+        class _Handler:
+            name = "spy"
+
+            def handle(self, reports):
+                created_seen.append([r.document_id for r in reports])
+
+        from radis.reports.api import viewsets
+
+        # Register a spy handler; the bulk path schedules its invocation via
+        # transaction.on_commit, so it must NOT run until the block commits.
+        self.addCleanup(setattr, viewsets, "reports_created_handlers", [])
+        viewsets.reports_created_handlers = [_Handler()]
+        viewsets.reports_updated_handlers = []
+
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            created, _ = _bulk_upsert_reports(
+                [validated("commit-1", group=self.group)]
+            )
+            # Inside the block, before commit, the handler has not run yet.
+            assert created == ["commit-1"]
+            assert created_seen == []
+
+        # After the with-block the captured on_commit callback executed.
+        assert len(callbacks) == 1
+        assert created_seen == [["commit-1"]]
+
+    def test_no_handlers_fire_when_transaction_rolls_back(self):
+        self._seed()
+        fired: list[str] = []
+
+        class _Handler:
+            name = "spy"
+
+            def handle(self, reports):
+                fired.append("called")
+
+        from radis.reports.api import viewsets
+
+        self.addCleanup(setattr, viewsets, "reports_created_handlers", [])
+        viewsets.reports_created_handlers = [_Handler()]
+        viewsets.reports_updated_handlers = []
+
+        # A duplicate-in-batch raises IntegrityError inside the atomic block, so
+        # the on_commit callback is discarded and the handler never fires.
+        with self.assertRaises(IntegrityError):
+            with self.captureOnCommitCallbacks(execute=True):
+                _bulk_upsert_reports(
+                    [
+                        validated("rb", group=self.group),
+                        validated("rb", group=self.group),
+                    ]
+                )
+
+        assert fired == []
+        assert Report.objects.filter(document_id="rb").count() == 0
+
+
+# --------------------------------------------------------------------------- #
+# Cascade on delete
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_deleting_report_cascades_metadata_and_search_vector():
+    LanguageFactory.create(code="en")
+    report = ReportFactory.create(
+        document_id="cascade-1",
+        language=Language.objects.get(code="en"),
+        modalities=["CT", "MR"],
+    )
+    # Saving a Report creates its search vector via the pgsearch post_save signal.
+    assert ReportSearchVector.objects.filter(report=report).exists()
+    assert report.metadata.exists()
+    report_pk = report.pk
+
+    report.delete()
+
+    assert not Report.objects.filter(pk=report_pk).exists()
+    # Metadata has on_delete=CASCADE
+    assert not Metadata.objects.filter(report_id=report_pk).exists()
+    # OneToOne search vector has on_delete=CASCADE
+    assert not ReportSearchVector.objects.filter(report_id=report_pk).exists()
+    # M2M through rows are removed, but the Modality rows themselves survive.
+    through = Report.modalities.through
+    assert not through.objects.filter(report_id=report_pk).exists()
+    assert Modality.objects.filter(code__in=["CT", "MR"]).count() == 2
+
+
+@pytest.mark.django_db
+def test_deleting_report_keeps_shared_language_and_modalities():
+    """Cascade must not delete shared lookup rows used by other reports."""
+    LanguageFactory.create(code="en")
+    ModalityFactory.create(code="CT")
+    keep = ReportFactory.create(document_id="keep", modalities=["CT"])
+    drop = ReportFactory.create(document_id="drop", modalities=["CT"])
+
+    drop.delete()
+
+    keep.refresh_from_db()
+    assert Modality.objects.filter(code="CT").exists()
+    assert Language.objects.filter(code="en").exists()
+    assert keep.modality_codes == ["CT"]
+
+
+@pytest.mark.django_db
+def test_api_delete_removes_report_and_dependents():
+    group = GroupFactory.create()
+    admin = AdminUserFactory.create()
+    client = APIClient()
+    client.force_authenticate(user=admin)
+    # Avoid the on-commit search-sync handlers (no external FTS DB in tests).
+    from radis.reports.api import viewsets
+
+    viewsets.reports_created_handlers = []
+    viewsets.reports_deleted_handlers = []
+
+    client.post(LIST_URL, make_payload("del-api", group=group), format="json")
+    report = Report.objects.get(document_id="del-api")
+    pk = report.pk
+
+    response = client.delete(reverse("report-detail", args=["del-api"]))
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not Report.objects.filter(pk=pk).exists()
+    assert not Metadata.objects.filter(report_id=pk).exists()

--- a/radis/reports/tests/test_data_integrity.py
+++ b/radis/reports/tests/test_data_integrity.py
@@ -223,7 +223,12 @@ class BulkUpsertOnCommitTests(TestCase):
 
         # Register a spy handler; the bulk path schedules its invocation via
         # transaction.on_commit, so it must NOT run until the block commits.
-        self.addCleanup(setattr, viewsets, "reports_created_handlers", [])
+        self.addCleanup(
+            setattr, viewsets, "reports_created_handlers", viewsets.reports_created_handlers
+        )
+        self.addCleanup(
+            setattr, viewsets, "reports_updated_handlers", viewsets.reports_updated_handlers
+        )
         viewsets.reports_created_handlers = [_Handler()]
         viewsets.reports_updated_handlers = []
 
@@ -251,7 +256,12 @@ class BulkUpsertOnCommitTests(TestCase):
 
         from radis.reports.api import viewsets
 
-        self.addCleanup(setattr, viewsets, "reports_created_handlers", [])
+        self.addCleanup(
+            setattr, viewsets, "reports_created_handlers", viewsets.reports_created_handlers
+        )
+        self.addCleanup(
+            setattr, viewsets, "reports_updated_handlers", viewsets.reports_updated_handlers
+        )
         viewsets.reports_created_handlers = [_Handler()]
         viewsets.reports_updated_handlers = []
 
@@ -322,7 +332,7 @@ def test_deleting_report_keeps_shared_language_and_modalities():
 
 
 @pytest.mark.django_db
-def test_api_delete_removes_report_and_dependents():
+def test_api_delete_removes_report_and_dependents(monkeypatch):
     group = GroupFactory.create()
     admin = AdminUserFactory.create()
     client = APIClient()
@@ -330,8 +340,8 @@ def test_api_delete_removes_report_and_dependents():
     # Avoid the on-commit search-sync handlers (no external FTS DB in tests).
     from radis.reports.api import viewsets
 
-    viewsets.reports_created_handlers = []
-    viewsets.reports_deleted_handlers = []
+    monkeypatch.setattr(viewsets, "reports_created_handlers", [])
+    monkeypatch.setattr(viewsets, "reports_deleted_handlers", [])
 
     client.post(LIST_URL, make_payload("del-api", group=group), format="json")
     report = Report.objects.get(document_id="del-api")

--- a/radis/reports/tests/test_patient_age.py
+++ b/radis/reports/tests/test_patient_age.py
@@ -1,0 +1,124 @@
+"""DB tests for the ``Report.patient_age`` generated column.
+
+``patient_age`` is a Postgres-persisted ``GeneratedField`` (see
+``reports/models.py``) backed by the ``calc_age`` SQL function from migration
+``0011_report_patient_age.py``:
+
+    EXTRACT(YEAR FROM age(study_datetime, patient_birth_date::timestamp))
+
+i.e. the number of *completed* years between birth and the study, evaluated at
+study time (age-at-study, not age-today). These tests insert reports with known
+birth dates / study datetimes and assert the computed value after
+``refresh_from_db``.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from radis.reports.factories import LanguageFactory, ReportFactory
+
+
+def _make_report(birth_date: date, study_dt: datetime):
+    language = LanguageFactory.create(code="en")
+    return ReportFactory.create(
+        language=language,
+        patient_birth_date=birth_date,
+        study_datetime=study_dt,
+    )
+
+
+@pytest.mark.django_db
+def test_patient_age_basic_completed_years():
+    report = _make_report(
+        date(1980, 1, 15),
+        datetime(2024, 3, 15, 10, 30, tzinfo=timezone.utc),
+    )
+    report.refresh_from_db()
+    # Born 1980-01-15, study 2024-03-15 -> 44th birthday already passed.
+    assert report.patient_age == 44
+
+
+@pytest.mark.django_db
+def test_patient_age_day_before_birthday():
+    """Study one day before the birthday -> age has NOT yet ticked over."""
+    report = _make_report(
+        date(1990, 6, 10),
+        datetime(2024, 6, 9, 8, 0, tzinfo=timezone.utc),
+    )
+    report.refresh_from_db()
+    # 2024-06-09 is the day before the 34th birthday -> still 33.
+    assert report.patient_age == 33
+
+
+@pytest.mark.django_db
+def test_patient_age_on_birthday():
+    """Study exactly on the birthday -> age ticks over that day."""
+    report = _make_report(
+        date(1990, 6, 10),
+        datetime(2024, 6, 10, 0, 1, tzinfo=timezone.utc),
+    )
+    report.refresh_from_db()
+    assert report.patient_age == 34
+
+
+@pytest.mark.django_db
+def test_patient_age_day_after_birthday():
+    report = _make_report(
+        date(1990, 6, 10),
+        datetime(2024, 6, 11, 8, 0, tzinfo=timezone.utc),
+    )
+    report.refresh_from_db()
+    assert report.patient_age == 34
+
+
+@pytest.mark.django_db
+def test_patient_age_leap_year_birthday_before_feb29_nonleap():
+    """Born on a leap day (Feb 29). In a non-leap study year, the 'birthday'
+    effectively lands on Mar 1, so Feb 28 of that year is still the prior age.
+    """
+    # Born 2000-02-29. Study 2023-02-28 (2023 is not a leap year).
+    report = _make_report(
+        date(2000, 2, 29),
+        datetime(2023, 2, 28, 12, 0, tzinfo=timezone.utc),
+    )
+    report.refresh_from_db()
+    # Postgres age(): on 2023-02-28 the patient is still 22 (turns 23 on 03-01).
+    assert report.patient_age == 22
+
+
+@pytest.mark.django_db
+def test_patient_age_leap_year_birthday_on_feb29_leap_study():
+    """Born Feb 29, study on a real Feb 29 in a leap year -> birthday hits."""
+    report = _make_report(
+        date(2000, 2, 29),
+        datetime(2024, 2, 29, 9, 0, tzinfo=timezone.utc),
+    )
+    report.refresh_from_db()
+    assert report.patient_age == 24
+
+
+@pytest.mark.django_db
+def test_patient_age_recomputed_on_update():
+    """The persisted generated column must be recomputed when inputs change."""
+    report = _make_report(
+        date(1980, 1, 15),
+        datetime(2000, 1, 15, 10, 0, tzinfo=timezone.utc),
+    )
+    report.refresh_from_db()
+    assert report.patient_age == 20
+
+    report.study_datetime = datetime(2024, 1, 15, 10, 0, tzinfo=timezone.utc)
+    report.save()
+    report.refresh_from_db()
+    assert report.patient_age == 44
+
+
+@pytest.mark.django_db
+def test_patient_age_same_day_birth_and_study_is_zero():
+    report = _make_report(
+        date(2024, 5, 1),
+        datetime(2024, 5, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    report.refresh_from_db()
+    assert report.patient_age == 0

--- a/radis/reports/tests/test_patient_age.py
+++ b/radis/reports/tests/test_patient_age.py
@@ -12,7 +12,7 @@ birth dates / study datetimes and assert the computed value after
 ``refresh_from_db``.
 """
 
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 
 import pytest
 
@@ -32,7 +32,7 @@ def _make_report(birth_date: date, study_dt: datetime):
 def test_patient_age_basic_completed_years():
     report = _make_report(
         date(1980, 1, 15),
-        datetime(2024, 3, 15, 10, 30, tzinfo=timezone.utc),
+        datetime(2024, 3, 15, 10, 30, tzinfo=UTC),
     )
     report.refresh_from_db()
     # Born 1980-01-15, study 2024-03-15 -> 44th birthday already passed.
@@ -44,7 +44,7 @@ def test_patient_age_day_before_birthday():
     """Study one day before the birthday -> age has NOT yet ticked over."""
     report = _make_report(
         date(1990, 6, 10),
-        datetime(2024, 6, 9, 8, 0, tzinfo=timezone.utc),
+        datetime(2024, 6, 9, 8, 0, tzinfo=UTC),
     )
     report.refresh_from_db()
     # 2024-06-09 is the day before the 34th birthday -> still 33.
@@ -56,7 +56,7 @@ def test_patient_age_on_birthday():
     """Study exactly on the birthday -> age ticks over that day."""
     report = _make_report(
         date(1990, 6, 10),
-        datetime(2024, 6, 10, 0, 1, tzinfo=timezone.utc),
+        datetime(2024, 6, 10, 0, 1, tzinfo=UTC),
     )
     report.refresh_from_db()
     assert report.patient_age == 34
@@ -66,7 +66,7 @@ def test_patient_age_on_birthday():
 def test_patient_age_day_after_birthday():
     report = _make_report(
         date(1990, 6, 10),
-        datetime(2024, 6, 11, 8, 0, tzinfo=timezone.utc),
+        datetime(2024, 6, 11, 8, 0, tzinfo=UTC),
     )
     report.refresh_from_db()
     assert report.patient_age == 34
@@ -80,7 +80,7 @@ def test_patient_age_leap_year_birthday_before_feb29_nonleap():
     # Born 2000-02-29. Study 2023-02-28 (2023 is not a leap year).
     report = _make_report(
         date(2000, 2, 29),
-        datetime(2023, 2, 28, 12, 0, tzinfo=timezone.utc),
+        datetime(2023, 2, 28, 12, 0, tzinfo=UTC),
     )
     report.refresh_from_db()
     # Postgres age(): on 2023-02-28 the patient is still 22 (turns 23 on 03-01).
@@ -92,7 +92,7 @@ def test_patient_age_leap_year_birthday_on_feb29_leap_study():
     """Born Feb 29, study on a real Feb 29 in a leap year -> birthday hits."""
     report = _make_report(
         date(2000, 2, 29),
-        datetime(2024, 2, 29, 9, 0, tzinfo=timezone.utc),
+        datetime(2024, 2, 29, 9, 0, tzinfo=UTC),
     )
     report.refresh_from_db()
     assert report.patient_age == 24
@@ -103,12 +103,12 @@ def test_patient_age_recomputed_on_update():
     """The persisted generated column must be recomputed when inputs change."""
     report = _make_report(
         date(1980, 1, 15),
-        datetime(2000, 1, 15, 10, 0, tzinfo=timezone.utc),
+        datetime(2000, 1, 15, 10, 0, tzinfo=UTC),
     )
     report.refresh_from_db()
     assert report.patient_age == 20
 
-    report.study_datetime = datetime(2024, 1, 15, 10, 0, tzinfo=timezone.utc)
+    report.study_datetime = datetime(2024, 1, 15, 10, 0, tzinfo=UTC)
     report.save()
     report.refresh_from_db()
     assert report.patient_age == 44
@@ -118,7 +118,7 @@ def test_patient_age_recomputed_on_update():
 def test_patient_age_same_day_birth_and_study_is_zero():
     report = _make_report(
         date(2024, 5, 1),
-        datetime(2024, 5, 1, 12, 0, tzinfo=timezone.utc),
+        datetime(2024, 5, 1, 12, 0, tzinfo=UTC),
     )
     report.refresh_from_db()
     assert report.patient_age == 0

--- a/radis/reports/tests/test_serializers.py
+++ b/radis/reports/tests/test_serializers.py
@@ -1,0 +1,333 @@
+"""Direct unit tests for ``ReportSerializer``.
+
+These complement the API-level contract tests in ``test_api.py`` by exercising
+the serializer in isolation: the wire-format reshaping done in
+``to_internal_value`` / ``to_representation``, the unknown-field rejection in
+``validate``, the ``skip_document_id_unique`` context switch, and the
+type-validation error branches.
+
+The serializer's ``create``/``update`` touch the DB, so those tests are marked
+``django_db``; the pure (de)serialization tests do not need a database.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+from adit_radis_shared.accounts.factories import GroupFactory
+from rest_framework import validators
+from rest_framework.exceptions import ValidationError
+
+from radis.reports.api.serializers import ReportSerializer
+from radis.reports.factories import LanguageFactory, ReportFactory
+from radis.reports.models import Language, Report
+
+
+def wire_payload(document_id: str = "doc-ser-0001", **overrides) -> dict:
+    """A valid create payload in the flat wire format the serializer accepts.
+
+    ``language`` is a string, ``metadata`` a flat dict, ``modalities`` a list of
+    codes, ``groups`` a list of Group PKs.
+    """
+    group = overrides.pop("group", None)
+    group_pk = group.pk if group is not None else 1
+    payload = {
+        "document_id": document_id,
+        "language": "en",
+        "groups": [group_pk],
+        "pacs_aet": "synapse",
+        "pacs_name": "Synapse",
+        "pacs_link": "http://synapse.example/1",
+        "patient_id": "1234578",
+        "patient_birth_date": date(1976, 5, 23).isoformat(),
+        "patient_sex": "M",
+        "study_description": "CT of the Thorax",
+        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=timezone.utc).isoformat(),
+        "study_instance_uid": "34343-34343-34343",
+        "accession_number": "345348389",
+        "modalities": ["CT", "PT"],
+        "metadata": {"series_instance_uid": "1.2.3", "sop_instance_uid": "4.5.6"},
+        "body": "This is the report",
+    }
+    payload.update(overrides)
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# to_internal_value: wire format -> nested serializer format
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_to_internal_value_reshapes_language_metadata_modalities():
+    group = GroupFactory.create()
+    serializer = ReportSerializer(data=wire_payload(group=group))
+
+    assert serializer.is_valid(), serializer.errors
+    vd = serializer.validated_data
+
+    # language string -> {"code": ...}
+    assert vd["language"] == {"code": "en"}
+    # metadata dict -> list of {key, value}
+    assert sorted(vd["metadata"], key=lambda m: m["key"]) == [
+        {"key": "series_instance_uid", "value": "1.2.3"},
+        {"key": "sop_instance_uid", "value": "4.5.6"},
+    ]
+    # modalities list[str] -> list of {"code": ...}
+    assert [m["code"] for m in vd["modalities"]] == ["CT", "PT"]
+
+
+# FIXED: the three type-guard branches in ``to_internal_value`` now raise a
+# *dict-shaped* ``ValidationError`` (e.g. ``{"language": "Invalid language
+# type."}``). Previously they raised ``ValidationError("Invalid <x> type.")``
+# with a bare string detail, which a nested ``ModelSerializer`` tried to fold
+# into a field-keyed dict, raising an uncaught ``ValueError`` (HTTP 500) instead
+# of the intended clean ``ValidationError`` -> 400. These tests now assert the
+# correct 400 behavior.
+
+
+@pytest.mark.django_db
+def test_to_internal_value_rejects_non_string_language():
+    group = GroupFactory.create()
+    serializer = ReportSerializer(data=wire_payload(group=group, language=["en"]))
+
+    with pytest.raises(ValidationError) as exc:
+        serializer.is_valid(raise_exception=True)
+    assert "Invalid language type." in str(exc.value)
+
+
+@pytest.mark.django_db
+def test_to_internal_value_rejects_non_dict_metadata():
+    group = GroupFactory.create()
+    serializer = ReportSerializer(
+        data=wire_payload(group=group, metadata=[["k", "v"]])
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        serializer.is_valid(raise_exception=True)
+    assert "Invalid metadata type." in str(exc.value)
+
+
+@pytest.mark.django_db
+def test_to_internal_value_rejects_non_list_modalities():
+    group = GroupFactory.create()
+    serializer = ReportSerializer(
+        data=wire_payload(group=group, modalities={"code": "CT"})
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        serializer.is_valid(raise_exception=True)
+    assert "Invalid modalities type." in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# to_representation: model instance -> flat wire format (round trip)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_to_representation_collapses_to_wire_format():
+    LanguageFactory.create(code="en")
+    report = ReportFactory.create(
+        document_id="doc-repr-unit",
+        language=Language.objects.get(code="en"),
+        modalities=["CT", "MR"],
+    )
+
+    data = ReportSerializer(report).data
+
+    assert data["language"] == "en"
+    assert isinstance(data["metadata"], dict)
+    assert sorted(data["modalities"]) == ["CT", "MR"]
+    assert data["document_id"] == "doc-repr-unit"
+
+
+@pytest.mark.django_db
+def test_create_then_representation_round_trips():
+    """A payload run through create() and back through to_representation()
+    yields the same flat language/metadata/modalities shapes.
+
+    Note: ``to_internal_value`` mutates the *input* dict in place (it rewrites
+    ``data["language"]`` to ``{"code": ...}`` etc.), so we snapshot the original
+    wire values before validating and compare the representation against those.
+    """
+    group = GroupFactory.create()
+    payload = wire_payload(document_id="doc-roundtrip", group=group)
+    expected = {
+        "language": payload["language"],
+        "metadata": dict(payload["metadata"]),
+        "modalities": list(payload["modalities"]),
+        "document_id": payload["document_id"],
+    }
+    serializer = ReportSerializer(data=payload)
+    assert serializer.is_valid(), serializer.errors
+
+    report = serializer.save()
+    out = ReportSerializer(report).data
+
+    assert out["language"] == expected["language"]
+    assert out["metadata"] == expected["metadata"]
+    assert sorted(out["modalities"]) == sorted(expected["modalities"])
+    assert out["document_id"] == expected["document_id"]
+    # Document the in-place mutation side effect explicitly.
+    assert payload["language"] == {"code": "en"}
+
+
+# --------------------------------------------------------------------------- #
+# validate(): unknown-field rejection
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_validate_rejects_unknown_field():
+    group = GroupFactory.create()
+    payload = wire_payload(group=group)
+    payload["totally_unknown"] = "x"
+    serializer = ReportSerializer(data=payload)
+
+    with pytest.raises(ValidationError) as exc:
+        serializer.is_valid(raise_exception=True)
+    assert "unknown fields" in str(exc.value)
+    assert "totally_unknown" in str(exc.value)
+
+
+@pytest.mark.django_db
+def test_validate_accepts_exactly_known_fields():
+    group = GroupFactory.create()
+    serializer = ReportSerializer(data=wire_payload(group=group))
+    assert serializer.is_valid(), serializer.errors
+
+
+# --------------------------------------------------------------------------- #
+# Required-field validation branches
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_missing_required_body_is_invalid():
+    group = GroupFactory.create()
+    payload = wire_payload(group=group)
+    del payload["body"]
+    serializer = ReportSerializer(data=payload)
+
+    assert not serializer.is_valid()
+    assert "body" in serializer.errors
+
+
+@pytest.mark.django_db
+def test_invalid_patient_sex_is_rejected():
+    group = GroupFactory.create()
+    serializer = ReportSerializer(data=wire_payload(group=group, patient_sex="X"))
+
+    assert not serializer.is_valid()
+    assert "patient_sex" in serializer.errors
+
+
+# --------------------------------------------------------------------------- #
+# document_id uniqueness validator and the skip_document_id_unique switch
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_duplicate_document_id_rejected_by_unique_validator():
+    LanguageFactory.create(code="en")
+    ReportFactory.create(document_id="dup-doc", modalities=["CT"])
+    group = GroupFactory.create()
+
+    serializer = ReportSerializer(data=wire_payload(document_id="dup-doc", group=group))
+
+    assert not serializer.is_valid()
+    assert "document_id" in serializer.errors
+
+
+@pytest.mark.django_db
+def test_skip_document_id_unique_context_strips_unique_validator():
+    """With ``skip_document_id_unique`` in context the unique validator on
+    ``document_id`` is removed, so a colliding id validates (the bulk path relies
+    on this and resolves the collision itself)."""
+    LanguageFactory.create(code="en")
+    ReportFactory.create(document_id="dup-doc-skip", modalities=["CT"])
+    group = GroupFactory.create()
+
+    serializer = ReportSerializer(
+        data=wire_payload(document_id="dup-doc-skip", group=group),
+        context={"skip_document_id_unique": True},
+    )
+
+    assert serializer.is_valid(), serializer.errors
+    # the unique validator is no longer attached to the field
+    assert not any(
+        isinstance(v, validators.UniqueValidator)
+        for v in serializer.fields["document_id"].validators
+    )
+
+
+# --------------------------------------------------------------------------- #
+# update(): existing report mutation + metadata/modality replacement
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_update_replaces_metadata_and_modalities():
+    LanguageFactory.create(code="en")
+    group = GroupFactory.create()
+    report = ReportFactory.create(
+        document_id="doc-upd-unit",
+        language=Language.objects.get(code="en"),
+        modalities=["CT"],
+    )
+
+    updated = wire_payload(document_id="doc-upd-unit", group=group)
+    updated["body"] = "new body"
+    updated["modalities"] = ["US"]
+    updated["metadata"] = {"only": "one"}
+
+    serializer = ReportSerializer(report, data=updated)
+    assert serializer.is_valid(), serializer.errors
+    result = serializer.save()
+
+    result.refresh_from_db()
+    assert result.body == "new body"
+    assert result.modality_codes == ["US"]
+    assert {m.key: m.value for m in result.metadata.all()} == {"only": "one"}
+
+
+@pytest.mark.django_db
+def test_update_with_new_language_creates_it():
+    """``update()`` uses ``Language.objects.get_or_create(**language)`` (matching
+    ``create()``), so PUTting a brand-new language code onto an existing report
+    creates the ``Language`` and assigns it instead of raising
+    ``Language.DoesNotExist`` (which previously surfaced as an unhandled 500).
+    """
+    LanguageFactory.create(code="en")
+    group = GroupFactory.create()
+    report = ReportFactory.create(
+        document_id="doc-upd-lang",
+        language=Language.objects.get(code="en"),
+        modalities=["CT"],
+    )
+    assert not Language.objects.filter(code="zz").exists()
+
+    updated = wire_payload(document_id="doc-upd-lang", group=group, language="zz")
+    serializer = ReportSerializer(report, data=updated)
+    assert serializer.is_valid(), serializer.errors
+
+    result = serializer.save()
+
+    result.refresh_from_db()
+    assert result.language.code == "zz"
+    assert Language.objects.filter(code="zz").exists()
+
+
+@pytest.mark.django_db
+def test_many_true_serializes_list_of_reports():
+    LanguageFactory.create(code="en")
+    ReportFactory.create(document_id="m-1", modalities=["CT"])
+    ReportFactory.create(document_id="m-2", modalities=["MR"])
+
+    data = ReportSerializer(Report.objects.order_by("document_id"), many=True).data
+
+    ids = {row["document_id"] for row in data}
+    assert {"m-1", "m-2"} <= ids
+    for row in data:
+        assert isinstance(row["language"], str)
+        assert isinstance(row["modalities"], list)

--- a/radis/reports/tests/test_serializers.py
+++ b/radis/reports/tests/test_serializers.py
@@ -10,7 +10,7 @@ The serializer's ``create``/``update`` touch the DB, so those tests are marked
 ``django_db``; the pure (de)serialization tests do not need a database.
 """
 
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 
 import pytest
 from adit_radis_shared.accounts.factories import GroupFactory
@@ -41,7 +41,7 @@ def wire_payload(document_id: str = "doc-ser-0001", **overrides) -> dict:
         "patient_birth_date": date(1976, 5, 23).isoformat(),
         "patient_sex": "M",
         "study_description": "CT of the Thorax",
-        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=timezone.utc).isoformat(),
+        "study_datetime": datetime(2000, 8, 10, 11, 37, tzinfo=UTC).isoformat(),
         "study_instance_uid": "34343-34343-34343",
         "accession_number": "345348389",
         "modalities": ["CT", "PT"],

--- a/radis/reports/tests/test_serializers.py
+++ b/radis/reports/tests/test_serializers.py
@@ -76,6 +76,20 @@ def test_to_internal_value_reshapes_language_metadata_modalities():
     assert [m["code"] for m in vd["modalities"]] == ["CT", "PT"]
 
 
+@pytest.mark.django_db
+def test_to_internal_value_does_not_mutate_the_input_payload():
+    group = GroupFactory.create()
+    payload = wire_payload(group=group)
+    before = {key: value for key, value in payload.items()}
+
+    serializer = ReportSerializer(data=payload)
+
+    assert serializer.is_valid(), serializer.errors
+    # The wire-format reshaping must happen on a copy, not on the caller's
+    # payload (which may even be an immutable QueryDict).
+    assert payload == before
+
+
 # FIXED: the three type-guard branches in ``to_internal_value`` now raise a
 # *dict-shaped* ``ValidationError`` (e.g. ``{"language": "Invalid language
 # type."}``). Previously they raised ``ValidationError("Invalid <x> type.")``
@@ -145,31 +159,19 @@ def test_to_representation_collapses_to_wire_format():
 def test_create_then_representation_round_trips():
     """A payload run through create() and back through to_representation()
     yields the same flat language/metadata/modalities shapes.
-
-    Note: ``to_internal_value`` mutates the *input* dict in place (it rewrites
-    ``data["language"]`` to ``{"code": ...}`` etc.), so we snapshot the original
-    wire values before validating and compare the representation against those.
     """
     group = GroupFactory.create()
     payload = wire_payload(document_id="doc-roundtrip", group=group)
-    expected = {
-        "language": payload["language"],
-        "metadata": dict(payload["metadata"]),
-        "modalities": list(payload["modalities"]),
-        "document_id": payload["document_id"],
-    }
     serializer = ReportSerializer(data=payload)
     assert serializer.is_valid(), serializer.errors
 
     report = serializer.save()
     out = ReportSerializer(report).data
 
-    assert out["language"] == expected["language"]
-    assert out["metadata"] == expected["metadata"]
-    assert sorted(out["modalities"]) == sorted(expected["modalities"])
-    assert out["document_id"] == expected["document_id"]
-    # Document the in-place mutation side effect explicitly.
-    assert payload["language"] == {"code": "en"}
+    assert out["language"] == payload["language"]
+    assert out["metadata"] == payload["metadata"]
+    assert sorted(out["modalities"]) == sorted(payload["modalities"])
+    assert out["document_id"] == payload["document_id"]
 
 
 # --------------------------------------------------------------------------- #

--- a/radis/search/tests/test_views_e2e.py
+++ b/radis/search/tests/test_views_e2e.py
@@ -1,0 +1,405 @@
+"""End-to-end search through the *real* pgsearch provider (un-mocked).
+
+The sibling ``test_views.py`` patches ``radis.search.views.search_provider`` with
+a stub, so it never touches Postgres full-text search. These tests instead insert
+real ``Report`` rows (whose ``ReportSearchVector`` is populated by the pgsearch
+``post_save`` signal) and drive the whole stack:
+
+    HTTP GET /search/  ->  SearchForm  ->  QueryParser  ->  pgsearch.providers.search
+    ->  to_tsquery  ->  ReportSearchVector  ->  rendered results
+
+so we assert the seeded report is actually found and that the form's hard
+filters (modality, patient sex, age, study date, study description) propagate
+into the SQL and narrow the result set.
+
+Run with the test settings so the debug toolbar (which otherwise breaks the
+rendered view) is disabled::
+
+    DJANGO_SETTINGS_MODULE=radis.settings.test uv run pytest \
+        radis/search/tests/test_views_e2e.py
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from adit_radis_shared.accounts.factories import GroupFactory, UserFactory
+from django.test import Client
+
+from radis.reports.factories import LanguageFactory, ReportFactory
+from radis.search.site import search_provider
+
+pytestmark = pytest.mark.django_db
+
+
+def _user_with_active_group():
+    user = UserFactory.create(is_active=True)
+    group = GroupFactory.create()
+    user.groups.add(group)
+    user.active_group = group
+    user.save()
+    return user, group
+
+
+def _logged_in_client() -> tuple[Client, object]:
+    client = Client()
+    user, group = _user_with_active_group()
+    client.force_login(user)
+    return client, group
+
+
+def _seed_report(body: str, *, document_id: str, groups=None, **overrides) -> object:
+    """Create a Report (and, via signal, its search vector) with English config.
+
+    ``ReportFactory`` does not assign any groups by default, but search is now
+    group-scoped (the provider filters on the active group). Pass ``groups`` to
+    associate the report with the searching user's group so it is visible;
+    reports seeded without a group (or with a foreign group) are intentionally
+    invisible to that user.
+    """
+    language = LanguageFactory.create(code="en")
+    report = ReportFactory.create(
+        document_id=document_id,
+        language=language,
+        body=body,
+        **overrides,
+    )
+    if groups is not None:
+        report.groups.set(groups)
+    return report
+
+
+def _doc_ids(response) -> list[str]:
+    return [doc.document_id for doc in response.context["documents"]]
+
+
+def test_real_provider_is_registered():
+    """Guard: the un-mocked default provider must be the pgsearch one, otherwise
+    these tests would silently exercise nothing meaningful."""
+    assert search_provider is not None
+    assert search_provider.name == "PG Search"
+
+
+def test_search_finds_real_report_through_pgsearch():
+    client, group = _logged_in_client()
+    match = _seed_report(
+        "CT thorax demonstrates acute pneumonia in the left lower lobe.",
+        document_id="E2E-MATCH",
+        modalities=["CT"],
+        groups=[group],
+    )
+    _seed_report(
+        "MR of the knee shows a meniscus tear, no acute findings.",
+        document_id="E2E-NOMATCH",
+        modalities=["MR"],
+        groups=[group],
+    )
+
+    response = client.get("/search/", {"query": "pneumonia"})
+
+    assert response.status_code == 200
+    ids = _doc_ids(response)
+    assert match.document_id in ids
+    assert "E2E-NOMATCH" not in ids
+    assert response.context["total_count"] == 1
+    assert response.context["total_relation"] == "exact"
+
+
+def test_search_stemming_through_full_stack():
+    """With the language filter set to 'en' the query config matches the document
+    config (both english), so stemming applies and 'opacity' matches 'opacities'.
+
+    The ``language=en`` param is load-bearing: see
+    ``test_language_config_mismatch_disables_stemming`` for what happens without
+    it (the query defaults to the 'simple' config and stemming is lost).
+    """
+    client, group = _logged_in_client()
+    report = _seed_report(
+        "The lungs show multiple opacities bilaterally.",
+        document_id="E2E-STEM",
+        modalities=["CT"],
+        groups=[group],
+    )
+
+    response = client.get("/search/", {"query": "opacity", "language": "en"})
+
+    assert response.status_code == 200
+    assert _doc_ids(response) == [report.document_id]
+
+
+def test_boolean_query_through_full_stack():
+    client, group = _logged_in_client()
+    both = _seed_report(
+        "CT thorax shows pneumonia and a pleural effusion.",
+        document_id="E2E-BOTH",
+        modalities=["CT"],
+        groups=[group],
+    )
+    one = _seed_report(
+        "CT thorax shows pneumonia, no effusion.".replace("effusion", "clear"),
+        document_id="E2E-ONE",
+        modalities=["CT"],
+        groups=[group],
+    )
+
+    # language=en so the english-stemmed 'effus' lexeme in the document matches
+    # the english-stemmed query term.
+    response = client.get(
+        "/search/", {"query": "pneumonia AND effusion", "language": "en"}
+    )
+
+    ids = _doc_ids(response)
+    assert both.document_id in ids
+    assert one.document_id not in ids
+
+
+def test_language_config_mismatch_disables_stemming():
+    """Finding: when no language filter is selected the view resolves the query
+    text-search config to 'simple' (``code_to_language("")``), while reports are
+    indexed under their own language config (here english). Stemmed forms then
+    silently fail to match.
+
+    'opacities' is indexed under english (stem 'opac'); a 'simple'-config query
+    for 'opacity' produces the un-stemmed lexeme 'opacity' and does NOT match,
+    even though the exact word 'opacities' would. This documents a real
+    searchability gap for users who do not pick a language.
+    """
+    client, group = _logged_in_client()
+    report = _seed_report(
+        "The lungs show multiple opacities bilaterally.",
+        document_id="E2E-MISMATCH",
+        modalities=["CT"],
+        groups=[group],
+    )
+
+    # No language param -> query resolved with the 'simple' config, which does
+    # not stem. The document, however, was indexed under english, so its stored
+    # lexeme is the stem 'opac'. The mismatch means BOTH the stemmed query and
+    # the exact surface form miss:
+    assert _doc_ids(client.get("/search/", {"query": "opacity"})) == []
+    assert _doc_ids(client.get("/search/", {"query": "opacities"})) == []
+
+    # Selecting the matching language realigns the configs and the report is
+    # found (control showing the report is genuinely indexed and retrievable).
+    aligned = client.get("/search/", {"query": "opacity", "language": "en"})
+    assert _doc_ids(aligned) == [report.document_id]
+
+
+def test_modality_filter_propagates_into_query():
+    """The ``modalities`` form filter must reach ``_build_filter_query`` and
+    narrow results to reports carrying that modality."""
+    client, group = _logged_in_client()
+    ct = _seed_report(
+        "pneumonia on CT", document_id="E2E-CT", modalities=["CT"], groups=[group]
+    )
+    mr = _seed_report(
+        "pneumonia on MR", document_id="E2E-MR", modalities=["MR"], groups=[group]
+    )
+
+    response = client.get("/search/", {"query": "pneumonia", "modalities": ["CT"]})
+
+    ids = _doc_ids(response)
+    assert ct.document_id in ids
+    assert mr.document_id not in ids
+
+
+def test_patient_sex_filter_propagates_into_query():
+    client, group = _logged_in_client()
+    male = _seed_report(
+        "pneumonia case",
+        document_id="E2E-M",
+        modalities=["CT"],
+        patient_sex="M",
+        groups=[group],
+    )
+    female = _seed_report(
+        "pneumonia case",
+        document_id="E2E-F",
+        modalities=["CT"],
+        patient_sex="F",
+        groups=[group],
+    )
+
+    response = client.get("/search/", {"query": "pneumonia", "patient_sex": "F"})
+
+    ids = _doc_ids(response)
+    assert female.document_id in ids
+    assert male.document_id not in ids
+
+
+def test_study_description_filter_propagates_into_query():
+    client, group = _logged_in_client()
+    chest = _seed_report(
+        "pneumonia case",
+        document_id="E2E-CHEST",
+        modalities=["CT"],
+        study_description="CT Thorax with contrast",
+        groups=[group],
+    )
+    brain = _seed_report(
+        "pneumonia case",
+        document_id="E2E-BRAIN",
+        modalities=["CT"],
+        study_description="MR Brain",
+        groups=[group],
+    )
+
+    response = client.get(
+        "/search/", {"query": "pneumonia", "study_description": "thorax"}
+    )
+
+    ids = _doc_ids(response)
+    assert chest.document_id in ids  # icontains, case-insensitive
+    assert brain.document_id not in ids
+
+
+def test_study_date_filter_propagates_into_query():
+    client, group = _logged_in_client()
+    in_range = _seed_report(
+        "pneumonia case",
+        document_id="E2E-2023",
+        modalities=["CT"],
+        study_datetime=datetime(2023, 6, 15, 9, 0, tzinfo=timezone.utc),
+        groups=[group],
+    )
+    out_of_range = _seed_report(
+        "pneumonia case",
+        document_id="E2E-2010",
+        modalities=["CT"],
+        study_datetime=datetime(2010, 1, 1, 9, 0, tzinfo=timezone.utc),
+        groups=[group],
+    )
+
+    response = client.get(
+        "/search/",
+        {
+            "query": "pneumonia",
+            "study_date_from": "2023-01-01",
+            "study_date_till": "2023-12-31",
+        },
+    )
+
+    ids = _doc_ids(response)
+    assert in_range.document_id in ids
+    assert out_of_range.document_id not in ids
+
+
+def test_age_filter_propagates_into_query():
+    """``age_from``/``age_till`` map to ``patient_age`` bounds (a generated column
+    from study_datetime - patient_birth_date)."""
+    client, group = _logged_in_client()
+    # patient_age is computed; pick birth/study dates that yield a ~40yo and ~80yo.
+    young = _seed_report(
+        "pneumonia case",
+        document_id="E2E-YOUNG",
+        modalities=["CT"],
+        patient_birth_date=datetime(1983, 1, 1).date(),
+        study_datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),  # ~40
+        groups=[group],
+    )
+    old = _seed_report(
+        "pneumonia case",
+        document_id="E2E-OLD",
+        modalities=["CT"],
+        patient_birth_date=datetime(1943, 1, 1).date(),
+        study_datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),  # ~80
+        groups=[group],
+    )
+
+    # Age window 30..50 (multiples of 10, valid for the form) -> only the ~40yo.
+    response = client.get(
+        "/search/", {"query": "pneumonia", "age_from": 30, "age_till": 50}
+    )
+
+    ids = _doc_ids(response)
+    assert young.document_id in ids
+    assert old.document_id not in ids
+
+
+def test_no_match_real_query_returns_empty():
+    client, group = _logged_in_client()
+    _seed_report(
+        "CT thorax normal study",
+        document_id="E2E-NONE",
+        modalities=["CT"],
+        groups=[group],
+    )
+
+    response = client.get("/search/", {"query": "rumpelstiltskin"})
+
+    assert response.status_code == 200
+    assert _doc_ids(response) == []
+    assert response.context["total_count"] == 0
+
+
+def test_hostile_query_through_real_stack_does_not_500():
+    """A malformed/SQL-shaped query routed through the real parser + raw tsquery
+    provider must render a normal 200, not surface a DB ProgrammingError."""
+    client, group = _logged_in_client()
+    _seed_report(
+        "CT thorax pneumonia",
+        document_id="E2E-HOSTILE",
+        modalities=["CT"],
+        groups=[group],
+    )
+
+    response = client.get(
+        "/search/", {"query": "pneumonia; DROP TABLE reports;--"}
+    )
+
+    assert response.status_code == 200
+    # The report still exists (no injection executed).
+    from radis.reports.models import Report
+
+    assert Report.objects.filter(document_id="E2E-HOSTILE").exists()
+
+
+def test_search_does_not_leak_reports_from_other_groups():
+    """A user must only see reports belonging to their active group.
+
+    The view passes ``group=active_group.pk`` into ``SearchFilters`` and
+    ``radis.pgsearch.providers._build_filter_query`` now filters on it (mirroring
+    ``Report.objects.filter(groups=active_group)`` used by the report list/detail
+    views), so a report associated solely with an unrelated group is not
+    returned. This is the security-critical cross-group isolation guarantee.
+    """
+    client, my_group = _logged_in_client()
+    other_group = GroupFactory.create()
+    leaked = _seed_report(
+        "confidential pneumonia finding",
+        document_id="E2E-OTHERGROUP",
+        modalities=["CT"],
+    )
+    # Belongs ONLY to a group the searching user is not a member of.
+    leaked.groups.set([other_group])
+
+    response = client.get("/search/", {"query": "pneumonia"})
+
+    assert response.status_code == 200
+    assert leaked.document_id not in _doc_ids(response)
+
+
+def test_search_returns_reports_from_active_group():
+    """Positive counterpart to the leak test: a report belonging to the user's
+    active group IS returned (the group filter must not over-restrict and hide
+    legitimate same-group results)."""
+    client, my_group = _logged_in_client()
+    mine = _seed_report(
+        "pneumonia finding in my group",
+        document_id="E2E-MYGROUP",
+        modalities=["CT"],
+        groups=[my_group],
+    )
+    other_group = GroupFactory.create()
+    leaked = _seed_report(
+        "pneumonia finding in another group",
+        document_id="E2E-NOTMYGROUP",
+        modalities=["CT"],
+        groups=[other_group],
+    )
+
+    response = client.get("/search/", {"query": "pneumonia"})
+
+    assert response.status_code == 200
+    ids = _doc_ids(response)
+    assert mine.document_id in ids
+    assert leaked.document_id not in ids

--- a/radis/search/tests/test_views_e2e.py
+++ b/radis/search/tests/test_views_e2e.py
@@ -19,13 +19,15 @@ rendered view) is disabled::
         radis/search/tests/test_views_e2e.py
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from adit_radis_shared.accounts.factories import GroupFactory, UserFactory
+from django.contrib.auth.models import Group
 from django.test import Client
 
 from radis.reports.factories import LanguageFactory, ReportFactory
+from radis.reports.models import Report
 from radis.search.site import search_provider
 
 pytestmark = pytest.mark.django_db
@@ -40,14 +42,16 @@ def _user_with_active_group():
     return user, group
 
 
-def _logged_in_client() -> tuple[Client, object]:
+def _logged_in_client() -> tuple[Client, Group]:
     client = Client()
     user, group = _user_with_active_group()
     client.force_login(user)
     return client, group
 
 
-def _seed_report(body: str, *, document_id: str, groups=None, **overrides) -> object:
+def _seed_report(
+    body: str, *, document_id: str, groups: list[Group] | None = None, **overrides
+) -> Report:
     """Create a Report (and, via signal, its search vector) with English config.
 
     ``ReportFactory`` does not assign any groups by default, but search is now
@@ -258,14 +262,14 @@ def test_study_date_filter_propagates_into_query():
         "pneumonia case",
         document_id="E2E-2023",
         modalities=["CT"],
-        study_datetime=datetime(2023, 6, 15, 9, 0, tzinfo=timezone.utc),
+        study_datetime=datetime(2023, 6, 15, 9, 0, tzinfo=UTC),
         groups=[group],
     )
     out_of_range = _seed_report(
         "pneumonia case",
         document_id="E2E-2010",
         modalities=["CT"],
-        study_datetime=datetime(2010, 1, 1, 9, 0, tzinfo=timezone.utc),
+        study_datetime=datetime(2010, 1, 1, 9, 0, tzinfo=UTC),
         groups=[group],
     )
 
@@ -293,7 +297,7 @@ def test_age_filter_propagates_into_query():
         document_id="E2E-YOUNG",
         modalities=["CT"],
         patient_birth_date=datetime(1983, 1, 1).date(),
-        study_datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),  # ~40
+        study_datetime=datetime(2023, 1, 1, tzinfo=UTC),  # ~40
         groups=[group],
     )
     old = _seed_report(
@@ -301,7 +305,7 @@ def test_age_filter_propagates_into_query():
         document_id="E2E-OLD",
         modalities=["CT"],
         patient_birth_date=datetime(1943, 1, 1).date(),
-        study_datetime=datetime(2023, 1, 1, tzinfo=timezone.utc),  # ~80
+        study_datetime=datetime(2023, 1, 1, tzinfo=UTC),  # ~80
         groups=[group],
     )
 

--- a/radis/search/utils/query_parser.py
+++ b/radis/search/utils/query_parser.py
@@ -198,7 +198,7 @@ class QueryParser:
         word = ~(not_ | and_ | or_) + pp.Regex(r"[^\s()]+").set_parse_action(
             lambda t: TermNode("WORD", t[0])  # type: ignore
         )
-        phrase = pp.QuotedString(quoteChar='"', esc_char="\\").set_parse_action(
+        phrase = pp.QuotedString(quote_char='"', esc_char="\\").set_parse_action(
             lambda t: TermNode("PHRASE", t[0])  # type: ignore
         )
         term = phrase | word

--- a/radis/settings/base.py
+++ b/radis/settings/base.py
@@ -211,8 +211,12 @@ DEFAULT_FROM_EMAIL = SERVER_EMAIL
 # they can get support.
 SUPPORT_EMAIL = env.str("SUPPORT_EMAIL")
 
-# Also used by django-registration-redux to send account approval emails
-ADMINS = [(env.str("DJANGO_ADMIN_FULL_NAME"), env.str("DJANGO_ADMIN_EMAIL"))]
+# The Django server admins that will receive critical error notifications.
+ADMINS = [env.str("DJANGO_ADMIN_EMAIL")]
+
+# Used by django-registration-redux to send account approval emails to.
+# It expects (name, address) pairs.
+REGISTRATION_ADMINS = [(env.str("DJANGO_ADMIN_FULL_NAME"), env.str("DJANGO_ADMIN_EMAIL"))]
 
 # All REST API requests must come from authenticated clients
 REST_FRAMEWORK = {

--- a/radis/settings/test.py
+++ b/radis/settings/test.py
@@ -10,3 +10,7 @@ if not DATABASES["default"]["NAME"].startswith("test_"):  # noqa: F405
     DATABASES["default"]["TEST"] = {"NAME": test_database}  # noqa: F405
 
 DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda request: False}
+
+# No real backups as a side effect of tests that run the worker (the periodic
+# backup_db task would fire when a test run crosses its cron time).
+BACKUP_ENABLED = False

--- a/radis/subscriptions/forms.py
+++ b/radis/subscriptions/forms.py
@@ -111,8 +111,8 @@ class SubscriptionForm(forms.ModelForm):
         return age_till
 
     def clean(self) -> dict[str, Any] | None:
-        age_from = self.cleaned_data["age_from"]
-        age_till = self.cleaned_data["age_till"]
+        age_from = self.cleaned_data.get("age_from")
+        age_till = self.cleaned_data.get("age_till")
 
         if age_from is not None and age_till is not None and age_from >= age_till:
             raise forms.ValidationError("Age from must be less than age till")

--- a/radis/subscriptions/processors.py
+++ b/radis/subscriptions/processors.py
@@ -64,7 +64,7 @@ class SubscriptionTaskProcessor(AnalysisTaskProcessor):
                 subscription=task.job.subscription,
                 job=task.job,
                 report=report,
-                filter_fields_results=result.model_dump(),
+                answers=result.model_dump(),
             )
             logger.debug(f"Report {report.pk} was accepted by subscription {subscription.pk}")
         else:

--- a/radis/subscriptions/processors.py
+++ b/radis/subscriptions/processors.py
@@ -46,26 +46,31 @@ class SubscriptionTaskProcessor(AnalysisTaskProcessor):
                 db.close_old_connections()
 
     def process_report(self, report: Report, task: SubscriptionTask) -> None:
-        subscription: Subscription = task.job.subscription
-        Schema = generate_questions_schema(subscription.questions)
-        prompt = Template(settings.QUESTIONS_SYSTEM_PROMPT).substitute(
-            {
-                "report": report.body,
-                "questions": generate_questions_for_prompt(subscription.questions),
-            }
-        )
-        result = self.client.extract_data(prompt, Schema)
-
-        is_accepted = all(
-            [getattr(result, field_name) for field_name in result.__pydantic_fields__]
-        )
-        if is_accepted:
-            SubscribedItem.objects.create(
-                subscription=task.job.subscription,
-                job=task.job,
-                report=report,
-                answers=result.model_dump(),
+        # Runs in a worker thread; its connection must be closed in that same
+        # thread (the close in process_task only reaches the main thread).
+        try:
+            subscription: Subscription = task.job.subscription
+            Schema = generate_questions_schema(subscription.questions)
+            prompt = Template(settings.QUESTIONS_SYSTEM_PROMPT).substitute(
+                {
+                    "report": report.body,
+                    "questions": generate_questions_for_prompt(subscription.questions),
+                }
             )
-            logger.debug(f"Report {report.pk} was accepted by subscription {subscription.pk}")
-        else:
-            logger.debug(f"Report {report.pk} was rejected by subscription {subscription.pk}")
+            result = self.client.extract_data(prompt, Schema)
+
+            is_accepted = all(
+                [getattr(result, field_name) for field_name in result.__pydantic_fields__]
+            )
+            if is_accepted:
+                SubscribedItem.objects.create(
+                    subscription=task.job.subscription,
+                    job=task.job,
+                    report=report,
+                    answers=result.model_dump(),
+                )
+                logger.debug(f"Report {report.pk} was accepted by subscription {subscription.pk}")
+            else:
+                logger.debug(f"Report {report.pk} was rejected by subscription {subscription.pk}")
+        finally:
+            db.close_old_connections()

--- a/radis/subscriptions/tests/test_forms.py
+++ b/radis/subscriptions/tests/test_forms.py
@@ -1,0 +1,82 @@
+"""Tests for SubscriptionForm age validators.
+
+AGE_STEP=10, MIN_AGE=0, MAX_AGE=120 (radis.search.forms). The form enforces:
+- age_from / age_till must be multiples of AGE_STEP (when provided)
+- age_from must be strictly less than age_till (when both provided)
+- both are optional (None passes)
+"""
+
+import pytest
+from adit_radis_shared.accounts.factories import GroupFactory, UserFactory
+
+from radis.reports.factories import LanguageFactory
+from radis.search.forms import AGE_STEP
+from radis.subscriptions.forms import SubscriptionForm
+
+
+def _form_data(**overrides) -> dict:
+    data = {
+        "name": "My Subscription",
+        "query": "pneumonia",
+        "language": "",
+        "modalities": [],
+        "study_description": "",
+        "patient_sex": "",
+        "patient_id": "",
+        "age_from": "",
+        "age_till": "",
+        "send_finished_mail": False,
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.fixture
+def _ref_data(db):
+    # The form's __init__ queries Language/Modality choices.
+    LanguageFactory.create(code="en")
+    UserFactory.create()
+    GroupFactory.create()
+
+
+@pytest.mark.django_db
+def test_valid_age_range_passes(_ref_data):
+    form = SubscriptionForm(data=_form_data(age_from=20, age_till=60))
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_blank_ages_pass(_ref_data):
+    form = SubscriptionForm(data=_form_data(age_from="", age_till=""))
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+def test_age_from_not_multiple_of_step_is_rejected(_ref_data):
+    form = SubscriptionForm(data=_form_data(age_from=25, age_till=60))
+    assert not form.is_valid()
+    assert "age_from" in form.errors
+    assert f"multiple of {AGE_STEP}" in str(form.errors["age_from"])
+
+
+@pytest.mark.django_db
+def test_age_till_not_multiple_of_step_is_rejected(_ref_data):
+    form = SubscriptionForm(data=_form_data(age_from=20, age_till=55))
+    assert not form.is_valid()
+    assert "age_till" in form.errors
+    assert f"multiple of {AGE_STEP}" in str(form.errors["age_till"])
+
+
+@pytest.mark.django_db
+def test_age_from_must_be_less_than_age_till(_ref_data):
+    form = SubscriptionForm(data=_form_data(age_from=60, age_till=60))
+    assert not form.is_valid()
+    # Cross-field error lands in non-field errors.
+    assert "Age from must be less than age till" in str(form.errors)
+
+
+@pytest.mark.django_db
+def test_age_from_greater_than_age_till_is_rejected(_ref_data):
+    form = SubscriptionForm(data=_form_data(age_from=80, age_till=40))
+    assert not form.is_valid()
+    assert "Age from must be less than age till" in str(form.errors)

--- a/radis/subscriptions/tests/test_processors.py
+++ b/radis/subscriptions/tests/test_processors.py
@@ -44,9 +44,8 @@ def make_capturing_openai_mock(answers: dict[str, bool]) -> tuple[MagicMock, _Ca
     every ``parse`` call (model, messages, response_format).
     """
     capture = _Capture()
-    Result = create_model(  # type: ignore[call-overload]
-        "Result", **{name: (bool, ...) for name in answers}
-    )
+    field_definitions: dict[str, Any] = {name: (bool, ...) for name in answers}
+    Result = create_model("Result", **field_definitions)
     parsed = Result(**answers)
 
     def fake_parse(*, model: str, messages: Any, response_format: Any) -> MagicMock:
@@ -204,8 +203,8 @@ def test_subscribed_item_created_when_all_answers_true():
         SubscriptionTaskProcessor(task).start()
 
     item = SubscribedItem.objects.get()
-    assert item.report_id == report.pk
-    assert item.subscription_id == task.job.subscription_id
+    assert item.report == report
+    assert item.subscription == task.job.subscription
     assert item.answers == {"question_0": True, "question_1": True}
 
 

--- a/radis/subscriptions/tests/test_processors.py
+++ b/radis/subscriptions/tests/test_processors.py
@@ -1,0 +1,225 @@
+"""Tests for the subscriptions LLM accept/reject gate (processors.py).
+
+The gate (``SubscriptionTaskProcessor.process_report``) sends the report body
+plus the subscription questions to the LLM, receives a per-question boolean
+result, and creates a ``SubscribedItem`` only if EVERY question answered truthy.
+
+The LLM is mocked at the ``openai.OpenAI`` boundary with a fake that CAPTURES
+the prompt and the requested schema so we can assert the report text + questions
+reach the model.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from adit_radis_shared.accounts.factories import GroupFactory, UserFactory
+from adit_radis_shared.common.utils.testing_helpers import add_user_to_group
+from pydantic import BaseModel, create_model
+
+from radis.reports.factories import ReportFactory
+from radis.subscriptions.factories import (
+    QuestionFactory,
+    SubscriptionFactory,
+    SubscriptionJobFactory,
+    SubscriptionTaskFactory,
+)
+from radis.subscriptions.models import SubscribedItem, SubscriptionJob, SubscriptionTask
+from radis.subscriptions.processors import SubscriptionTaskProcessor
+from radis.subscriptions.utils.processor_utils import (
+    generate_questions_for_prompt,
+    generate_questions_schema,
+)
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+
+def make_capturing_openai_mock(answers: dict[str, bool]) -> tuple[MagicMock, _Capture]:
+    """Fake ``openai.OpenAI`` returning a parsed model built from ``answers``.
+
+    ``answers`` maps ``question_0``/``question_1``/... -> bool. The fake records
+    every ``parse`` call (model, messages, response_format).
+    """
+    capture = _Capture()
+    Result = create_model(  # type: ignore[call-overload]
+        "Result", **{name: (bool, ...) for name in answers}
+    )
+    parsed = Result(**answers)
+
+    def fake_parse(*, model: str, messages: Any, response_format: Any) -> MagicMock:
+        capture.calls.append(
+            {"model": model, "messages": list(messages), "response_format": response_format}
+        )
+        return MagicMock(choices=[MagicMock(message=MagicMock(parsed=parsed))])
+
+    openai_mock = MagicMock()
+    openai_mock.beta.chat.completions.parse.side_effect = fake_parse
+    return openai_mock, capture
+
+
+def _make_task_with_reports(
+    question_texts: list[str], num_reports: int = 1
+) -> SubscriptionTask:
+    """Build a SubscriptionTask whose owner has an active group and whose
+    reports are visible to that group."""
+    user = UserFactory.create(is_active=True)
+    group = GroupFactory.create()
+    add_user_to_group(user, group, force_activate_group=True)
+
+    subscription = SubscriptionFactory.create(owner=user, group=group)
+    for text in question_texts:
+        QuestionFactory.create(subscription=subscription, question=text)
+
+    # Tasks are only processed once the job is PENDING (set by
+    # process_subscription_job before enqueueing). AnalysisTaskProcessor.start()
+    # asserts this, so reflect the real runtime state here.
+    job = SubscriptionJobFactory.create(
+        subscription=subscription, owner=user, status=SubscriptionJob.Status.PENDING
+    )
+    task = SubscriptionTaskFactory.create(job=job)
+
+    for _ in range(num_reports):
+        report = ReportFactory.create()
+        report.groups.add(group)
+        task.reports.add(report)
+
+    return task
+
+
+# --------------------------------------------------------------------------- #
+# processor_utils: schema + prompt generation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_generate_questions_schema_creates_boolean_fields_per_question():
+    subscription = SubscriptionFactory.create()
+    QuestionFactory.create(subscription=subscription, question="Is there a fracture?")
+    QuestionFactory.create(subscription=subscription, question="Is it acute?")
+
+    Schema = generate_questions_schema(subscription.questions)
+
+    assert set(Schema.model_fields) == {"question_0", "question_1"}
+    for field in Schema.model_fields.values():
+        assert field.annotation is bool
+
+
+@pytest.mark.django_db
+def test_generate_questions_for_prompt_enumerates_questions():
+    subscription = SubscriptionFactory.create()
+    QuestionFactory.create(subscription=subscription, question="Is there a fracture?")
+    QuestionFactory.create(subscription=subscription, question="Is it acute?")
+
+    prompt = generate_questions_for_prompt(subscription.questions)
+
+    assert "question_0: Is there a fracture?" in prompt
+    assert "question_1: Is it acute?" in prompt
+
+
+# --------------------------------------------------------------------------- #
+# Gate: report text + questions reach the model
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db(transaction=True)
+def test_report_body_and_questions_reach_the_model():
+    task = _make_task_with_reports(
+        ["Is there a pulmonary nodule?", "Is it larger than 5mm?"], num_reports=1
+    )
+    report = task.reports.get()
+
+    # Reject (all False) so this test isolates the prompt/schema plumbing from
+    # the accept path (covered by test_subscribed_item_created_when_all_answers_true).
+    openai_mock, capture = make_capturing_openai_mock(
+        {"question_0": False, "question_1": False}
+    )
+    with patch("openai.OpenAI", return_value=openai_mock):
+        SubscriptionTaskProcessor(task).start()
+
+    assert len(capture.calls) == 1
+    call = capture.calls[0]
+    assert call["messages"][0]["role"] == "system"
+    sent = call["messages"][0]["content"]
+
+    assert report.body in sent
+    assert "Is there a pulmonary nodule?" in sent
+    assert "Is it larger than 5mm?" in sent
+
+    # Requested schema carries one boolean field per question.
+    schema = call["response_format"]
+    assert issubclass(schema, BaseModel)
+    assert set(schema.model_fields) == {"question_0", "question_1"}
+
+
+# --------------------------------------------------------------------------- #
+# Gate: reject decision
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db(transaction=True)
+def test_no_subscribed_item_when_any_answer_is_false():
+    task = _make_task_with_reports(["q one", "q two"], num_reports=1)
+
+    # One True, one False -> rejected (gate requires ALL truthy).
+    openai_mock, _ = make_capturing_openai_mock({"question_0": True, "question_1": False})
+    with patch("openai.OpenAI", return_value=openai_mock):
+        SubscriptionTaskProcessor(task).start()
+
+    assert SubscribedItem.objects.count() == 0
+    task.refresh_from_db()
+    assert task.status == SubscriptionTask.Status.SUCCESS
+
+
+@pytest.mark.django_db(transaction=True)
+def test_reports_not_in_active_group_are_skipped():
+    task = _make_task_with_reports(["q one"], num_reports=0)
+    # Report that is NOT in the owner's active group must be filtered out.
+    orphan = ReportFactory.create()
+    task.reports.add(orphan)
+
+    openai_mock, capture = make_capturing_openai_mock({"question_0": False})
+    with patch("openai.OpenAI", return_value=openai_mock):
+        SubscriptionTaskProcessor(task).start()
+
+    # The LLM was never consulted because no report matched the active group.
+    assert len(capture.calls) == 0
+    assert SubscribedItem.objects.count() == 0
+
+
+# --------------------------------------------------------------------------- #
+# Gate: accept decision -- exposes a real bug.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db(transaction=True)
+def test_subscribed_item_created_when_all_answers_true():
+    task = _make_task_with_reports(["q one", "q two"], num_reports=1)
+    report = task.reports.get()
+
+    openai_mock, _ = make_capturing_openai_mock({"question_0": True, "question_1": True})
+    with patch("openai.OpenAI", return_value=openai_mock):
+        SubscriptionTaskProcessor(task).start()
+
+    item = SubscribedItem.objects.get()
+    assert item.report_id == report.pk
+    assert item.subscription_id == task.job.subscription_id
+    assert item.answers == {"question_0": True, "question_1": True}
+
+
+@pytest.mark.django_db(transaction=True)
+def test_accept_path_succeeds_and_creates_item():
+    """The accept path completes cleanly: an accepted report creates exactly one
+    SubscribedItem and the task finishes SUCCESS (previously the wrong field name
+    raised inside the worker thread and marked the task FAILURE)."""
+    task = _make_task_with_reports(["q one"], num_reports=1)
+
+    openai_mock, _ = make_capturing_openai_mock({"question_0": True})
+    with patch("openai.OpenAI", return_value=openai_mock):
+        SubscriptionTaskProcessor(task).start()
+
+    task.refresh_from_db()
+    assert task.status == SubscriptionTask.Status.SUCCESS
+    assert SubscribedItem.objects.count() == 1

--- a/radis/subscriptions/tests/test_tasks_build.py
+++ b/radis/subscriptions/tests/test_tasks_build.py
@@ -165,7 +165,7 @@ def test_subscription_launcher_creates_one_preparing_job_per_subscription(monkey
 
     jobs = SubscriptionJob.objects.all()
     assert jobs.count() == 3
-    assert {j.subscription_id for j in jobs} == {s.pk for s in subs}
+    assert {j.subscription.pk for j in jobs} == {s.pk for s in subs}
     assert all(j.status == SubscriptionJob.Status.PREPARING for j in jobs)
     # Owner is copied from the subscription.
     for job in jobs:

--- a/radis/subscriptions/tests/test_tasks_build.py
+++ b/radis/subscriptions/tests/test_tasks_build.py
@@ -1,0 +1,172 @@
+"""Tests for subscriptions task orchestration (tasks.py):
+
+- process_subscription_job: query vs. filter path, batching into
+  SubscriptionTasks, report wiring, status transitions, last_refreshed update,
+  and the missing-provider error branches.
+- subscription_launcher: one PREPARING job per subscription.
+
+The existing test_tasks.py already covers the "only enqueue after PENDING"
+invariant; these focus on the build/launch behaviour.
+"""
+
+import pytest
+from adit_radis_shared.accounts.factories import GroupFactory, UserFactory
+from django.core.exceptions import ImproperlyConfigured
+
+from radis.reports.factories import LanguageFactory, ReportFactory
+from radis.subscriptions import site as subscription_site
+from radis.subscriptions.factories import SubscriptionFactory, SubscriptionJobFactory
+from radis.subscriptions.models import SubscriptionJob, SubscriptionTask
+from radis.subscriptions.site import SubscriptionFilterProvider, SubscriptionRetrievalProvider
+from radis.subscriptions.tasks import process_subscription_job, subscription_launcher
+
+
+def _preparing_job(query: str) -> SubscriptionJob:
+    user = UserFactory.create(is_active=True)
+    group = GroupFactory.create()
+    language = LanguageFactory.create(code="en")
+    subscription = SubscriptionFactory.create(
+        owner=user, group=group, language=language, query=query
+    )
+    job = SubscriptionJobFactory.create(subscription=subscription, owner=user)
+    job.status = SubscriptionJob.Status.PREPARING
+    job.save()
+    return job
+
+
+@pytest.mark.django_db
+def test_filter_path_used_when_query_empty(monkeypatch, settings):
+    settings.SUBSCRIPTION_REFRESH_TASK_BATCH_SIZE = 2
+    job = _preparing_job(query="")
+
+    doc_ids = ["S-1", "S-2", "S-3"]
+    for doc_id in doc_ids:
+        ReportFactory.create(document_id=doc_id)
+
+    used = {"filter": 0, "retrieve": 0}
+
+    def _filter(_filters):
+        used["filter"] += 1
+        return doc_ids
+
+    def _retrieve(_search):
+        used["retrieve"] += 1
+        return doc_ids
+
+    monkeypatch.setattr(
+        subscription_site,
+        "subscription_filter_provider",
+        SubscriptionFilterProvider(name="f", filter=_filter),
+    )
+    monkeypatch.setattr(
+        subscription_site,
+        "subscription_retrieval_provider",
+        SubscriptionRetrievalProvider(name="r", retrieve=_retrieve),
+    )
+    monkeypatch.setattr(SubscriptionTask, "delay", lambda self: None, raising=True)
+
+    process_subscription_job(int(job.pk))
+
+    # Empty query -> filter provider, never the retrieval provider.
+    assert used == {"filter": 1, "retrieve": 0}
+
+    tasks = list(job.tasks.all())
+    assert len(tasks) == 2  # ceil(3 / 2)
+    total_reports = sum(t.reports.count() for t in tasks)
+    assert total_reports == 3
+
+    job.refresh_from_db()
+    assert job.status == SubscriptionJob.Status.PENDING
+
+
+@pytest.mark.django_db
+def test_retrieval_path_used_when_query_present(monkeypatch, settings):
+    settings.SUBSCRIPTION_REFRESH_TASK_BATCH_SIZE = 100
+    job = _preparing_job(query="pneumonia")
+
+    doc_ids = ["Q-1", "Q-2"]
+    for doc_id in doc_ids:
+        ReportFactory.create(document_id=doc_id)
+
+    used = {"filter": 0, "retrieve": 0}
+    monkeypatch.setattr(
+        subscription_site,
+        "subscription_filter_provider",
+        SubscriptionFilterProvider(
+            name="f", filter=lambda _f: used.__setitem__("filter", used["filter"] + 1) or doc_ids
+        ),
+    )
+    monkeypatch.setattr(
+        subscription_site,
+        "subscription_retrieval_provider",
+        SubscriptionRetrievalProvider(
+            name="r",
+            retrieve=lambda _s: used.__setitem__("retrieve", used["retrieve"] + 1) or doc_ids,
+        ),
+    )
+    monkeypatch.setattr(SubscriptionTask, "delay", lambda self: None, raising=True)
+
+    process_subscription_job(int(job.pk))
+
+    # Non-empty query -> retrieval provider, never the filter provider.
+    assert used == {"filter": 0, "retrieve": 1}
+    assert job.tasks.count() == 1
+    assert job.tasks.get().reports.count() == 2
+
+
+@pytest.mark.django_db
+def test_last_refreshed_is_advanced(monkeypatch):
+    job = _preparing_job(query="")
+    before = job.subscription.last_refreshed
+
+    monkeypatch.setattr(
+        subscription_site,
+        "subscription_filter_provider",
+        SubscriptionFilterProvider(name="f", filter=lambda _f: []),
+    )
+    monkeypatch.setattr(SubscriptionTask, "delay", lambda self: None, raising=True)
+
+    process_subscription_job(int(job.pk))
+
+    job.subscription.refresh_from_db()
+    assert job.subscription.last_refreshed > before
+    # No documents -> no tasks created.
+    assert job.tasks.count() == 0
+
+
+@pytest.mark.django_db
+def test_missing_filter_provider_raises(monkeypatch):
+    job = _preparing_job(query="")
+    monkeypatch.setattr(subscription_site, "subscription_filter_provider", None)
+
+    with pytest.raises(ImproperlyConfigured):
+        process_subscription_job(int(job.pk))
+
+
+@pytest.mark.django_db
+def test_missing_retrieval_provider_raises(monkeypatch):
+    job = _preparing_job(query="pneumonia")
+    monkeypatch.setattr(subscription_site, "subscription_retrieval_provider", None)
+
+    with pytest.raises(ImproperlyConfigured):
+        process_subscription_job(int(job.pk))
+
+
+@pytest.mark.django_db
+def test_subscription_launcher_creates_one_preparing_job_per_subscription(monkeypatch):
+    # The launcher schedules job.delay via transaction.on_commit; stub it out so
+    # no real Procrastinate deferral happens.
+    monkeypatch.setattr(SubscriptionJob, "delay", lambda self: None, raising=True)
+
+    subs = [SubscriptionFactory.create() for _ in range(3)]
+
+    assert SubscriptionJob.objects.count() == 0
+    subscription_launcher(0)
+
+    jobs = SubscriptionJob.objects.all()
+    assert jobs.count() == 3
+    assert {j.subscription_id for j in jobs} == {s.pk for s in subs}
+    assert all(j.status == SubscriptionJob.Status.PREPARING for j in jobs)
+    # Owner is copied from the subscription.
+    for job in jobs:
+        assert job.owner_id == job.subscription.owner_id

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ constraints = [{ name = "autobahn", specifier = "<25.11.1" }]
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.23.0#2ea948f4492496de1c65f4aad04a603c1175d83a" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.25.0#793b48e440678968e8a933049113045c2f6a126f" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },
@@ -39,8 +39,6 @@ dependencies = [
     { name = "environs", extra = ["django"] },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-django" },
-    { name = "opentelemetry-instrumentation-psycopg" },
     { name = "opentelemetry-sdk" },
     { name = "procrastinate", extra = ["django"] },
     { name = "psycopg", extra = ["binary"] },
@@ -1893,81 +1891,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-instrumentation"
-version = "0.64b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "packaging" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/97/02fe6e1c8b1ffac42d0b429c18080edb24e0e0d18c86612edf72b5752382/opentelemetry_instrumentation-0.64b0.tar.gz", hash = "sha256:b47d528dead6271d7743114417eb67fc915bd9258111c48dbf9a4951d2efa88d", size = 41935, upload-time = "2026-06-24T15:19:12.951Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/0c/cb9fe342de5299c7af24582eb7d788661cc53a1c4b904da92309caaa9417/opentelemetry_instrumentation-0.64b0-py3-none-any.whl", hash = "sha256:133ab7ffca796557aec059bf6be3190a34b6dea987f25be3d9409e230cbdad8b", size = 35880, upload-time = "2026-06-24T15:18:17.277Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-dbapi"
-version = "0.64b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/9f/3c6ce6f4394faa1540f48b7d442f455582ca76449952506ce767a54f09bf/opentelemetry_instrumentation_dbapi-0.64b0.tar.gz", hash = "sha256:8e3a1528fc9753a04190a7e7bf0180c5abd059f3aa68ec3857edb363c9847c44", size = 20138, upload-time = "2026-06-24T15:19:24.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/1b/77972514bcc046741339b76e2cc104bef536c1433b45a2b39adbdadc9889/opentelemetry_instrumentation_dbapi-0.64b0-py3-none-any.whl", hash = "sha256:1caa96d438bf37f71dd778c9f1e03ba1f50b8ab54aeef68b2a630c93c05cddc6", size = 14812, upload-time = "2026-06-24T15:18:33.541Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-django"
-version = "0.64b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-wsgi" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/2e/8f6084eab186533b0574683a8c39e51803e6c34c21fc33e194f58352d704/opentelemetry_instrumentation_django-0.64b0.tar.gz", hash = "sha256:3d2673b4f77156b15b1b119c8849b50e3644cfc325f7a24c03602596de2dbba4", size = 25387, upload-time = "2026-06-24T15:19:24.795Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/ef/7e7857fae434e0eb0395d8a5b399c21efd23fe0f3c166ecdcb8596902541/opentelemetry_instrumentation_django-0.64b0-py3-none-any.whl", hash = "sha256:c1f628e53c22aa8f9cc9cbe6e61e781940da6eda5f910d26720ef8ac73e25afe", size = 18938, upload-time = "2026-06-24T15:18:34.449Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-psycopg"
-version = "0.64b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-dbapi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/d0/d0ef8b06ceb46f55e625b7f6c91d9a9d4c1ab17d535e60884428dd93afaa/opentelemetry_instrumentation_psycopg-0.64b0.tar.gz", hash = "sha256:e9f41fad425183392d97068dbe2ce6e938514520312cfd7bf409242bd800c013", size = 12115, upload-time = "2026-06-24T15:19:33.394Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/0d/35029ab3c8aa5da2eae18f6e3ddb0636425927cdbcf4770ffe5a8aaf2201/opentelemetry_instrumentation_psycopg-0.64b0-py3-none-any.whl", hash = "sha256:a9835b8749db71a9c1e075ae81c084b1f370130341ceff6a231095f89f48a0c6", size = 10823, upload-time = "2026-06-24T15:18:47.659Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-wsgi"
-version = "0.64b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/4f/0b5232a0d635eee5da7c85af503d2f00fdcac61cc6d4d4a69aadf1fa7a0e/opentelemetry_instrumentation_wsgi-0.64b0.tar.gz", hash = "sha256:1cce6ea28d1800c154e6ccdf52f05bae2f05c5e28ee44f0dddb17ada26208986", size = 19667, upload-time = "2026-06-24T15:19:46.407Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/5d/4da612cfe1ad96730dba19c9ab97f531be0558a918998e11478734cb36b2/opentelemetry_instrumentation_wsgi-0.64b0-py3-none-any.whl", hash = "sha256:5a3b0174f39072c0abb749be4ae7e469c7585e87cdfaf63665657b1a7058c105", size = 13787, upload-time = "2026-06-24T15:19:05.417Z" },
-]
-
-[[package]]
 name = "opentelemetry-proto"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2004,15 +1927,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
-]
-
-[[package]]
-name = "opentelemetry-util-http"
-version = "0.64b0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/1b/1029a805fd7242f7dfce91633b244c3b14a94d703232878f71e01ce862b1/opentelemetry_util_http-0.64b0.tar.gz", hash = "sha256:8a86a220dbfc56d736f47f1e5c4e7932a21fcf69052312e1bcf166444dc79322", size = 11102, upload-time = "2026-06-24T15:19:48.974Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/c7/5f8ec5b30546f2dc22cd5fc5759bce2ab5be6e89a2e710a405ac9ef64ed3/opentelemetry_util_http-0.64b0-py3-none-any.whl", hash = "sha256:c1e5350d25507c1afcd6076cf9ac062485a0a4f79cd9971366996fd3056bacdb", size = 8204, upload-time = "2026-06-24T15:19:09.02Z" },
 ]
 
 [[package]]
@@ -2102,7 +2016,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2889,7 +2803,6 @@ dev = [
     { name = "faker" },
     { name = "ipykernel" },
     { name = "ipython" },
-    { name = "nest-asyncio2" },
     { name = "pre-commit" },
     { name = "pydicom" },
     { name = "pyright" },
@@ -2918,7 +2831,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.23.0" },
+    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.25.0" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },
@@ -2973,7 +2886,6 @@ dev = [
     { name = "faker", specifier = ">=36.1.1" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "ipython", specifier = ">=8.32.0" },
-    { name = "nest-asyncio2", specifier = ">=1.7.2" },
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pydicom", specifier = ">=2.4.4" },
     { name = "pyright", specifier = ">=1.1.402" },
@@ -3646,70 +3558,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "2.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
-    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
-    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
-    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
-    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
-    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
-    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
-    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
-    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
-    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
-    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
-    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
-    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
-    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
-    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
-    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
-    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
-    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
-    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
-    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
-    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
-    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
-    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Test-coverage expansion across the reports API, chats, extractions, subscriptions, search, and exports — with the bugs the new tests surfaced fixed in the same branch:

- **Search returned reports from other groups** (group scoping fix)
- **Notes edit view exposed other users' notes**
- Report serializer 500s on invalid input / new-language PUT; payload mutation in `to_internal_value`
- Subscription matching and form crashes; search crash on punctuation-only queries; non-owner chat updates now 404
- **Connection hygiene**: extraction/subscription processor worker threads now close their thread-local Django connections (the subscription processor closed them only in the main thread — unreachable for workers; the extraction processor skipped the close on failures)

Infrastructure, aligned with adit and adit-radis-shared:

- adit-radis-shared **0.25.0** + full **nest_asyncio removal** (event-loop-independent test helpers)
- `ADMINS` deprecation fix (`REGISTRATION_ADMINS` for the approval-mail flow)
- Deprecated pyparsing `quoteChar` argument fixed in the search query parser
- **pytest now fails on any unexpected warning** (`"error"` in `filterwarnings`); test settings disable the periodic `backup_db` so suite runs can't fire a real `pg_dump`

## Verification

Full suite in the dev container with warnings-as-errors: **381 passed, 0 warnings, RC=0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)