### PR TITLE
Fail tests on unexpected warnings and fix processor connection leaks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(linen
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 markers = ["acceptance: mark a test as an acceptance test."]
 filterwarnings = [
+    # Fail on any warning not explicitly ignored below
+    "error",
     # We already fixed this, so we only need to remove this ignore with next major version of factory boy
     "ignore:.*Factory._after_postgeneration will stop saving the instance:DeprecationWarning",
     'ignore:.*use of fork\(\) may lead to deadlocks.*:DeprecationWarning',

--- a/radis/extractions/processors.py
+++ b/radis/extractions/processors.py
@@ -37,12 +37,16 @@ class ExtractionTaskProcessor(AnalysisTaskProcessor):
                 db.close_old_connections()
 
     def process_instance(self, instance: ExtractionInstance) -> None:
-        assert not instance.is_processed
-        instance.text = instance.report.body
-        self.process_output_fields(instance)
-        instance.is_processed = True
-        instance.save()
-        db.close_old_connections()
+        # Runs in a worker thread; its connection must be closed in that same
+        # thread, also when processing fails.
+        try:
+            assert not instance.is_processed
+            instance.text = instance.report.body
+            self.process_output_fields(instance)
+            instance.is_processed = True
+            instance.save()
+        finally:
+            db.close_old_connections()
 
     def process_output_fields(self, instance: ExtractionInstance) -> None:
         job = instance.task.job

--- a/radis/extractions/processors.py
+++ b/radis/extractions/processors.py
@@ -46,7 +46,7 @@ class ExtractionTaskProcessor(AnalysisTaskProcessor):
             instance.is_processed = True
             instance.save()
         finally:
-            db.close_old_connections()
+            db.connections.close_all()
 
     def process_output_fields(self, instance: ExtractionInstance) -> None:
         job = instance.task.job

--- a/radis/settings/test.py
+++ b/radis/settings/test.py
@@ -10,3 +10,7 @@ if not DATABASES["default"]["NAME"].startswith("test_"):  # noqa: F405
     DATABASES["default"]["TEST"] = {"NAME": test_database}  # noqa: F405
 
 DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda request: False}
+
+# No real backups as a side effect of tests that run the worker (the periodic
+# backup_db task would fire when a test run crosses its cron time).
+BACKUP_ENABLED = False

--- a/radis/subscriptions/processors.py
+++ b/radis/subscriptions/processors.py
@@ -46,26 +46,31 @@ class SubscriptionTaskProcessor(AnalysisTaskProcessor):
                 db.close_old_connections()
 
     def process_report(self, report: Report, task: SubscriptionTask) -> None:
-        subscription: Subscription = task.job.subscription
-        Schema = generate_questions_schema(subscription.questions)
-        prompt = Template(settings.QUESTIONS_SYSTEM_PROMPT).substitute(
-            {
-                "report": report.body,
-                "questions": generate_questions_for_prompt(subscription.questions),
-            }
-        )
-        result = self.client.extract_data(prompt, Schema)
-
-        is_accepted = all(
-            [getattr(result, field_name) for field_name in result.__pydantic_fields__]
-        )
-        if is_accepted:
-            SubscribedItem.objects.create(
-                subscription=task.job.subscription,
-                job=task.job,
-                report=report,
-                answers=result.model_dump(),
+        # Runs in a worker thread; its connection must be closed in that same
+        # thread (the close in process_task only reaches the main thread).
+        try:
+            subscription: Subscription = task.job.subscription
+            Schema = generate_questions_schema(subscription.questions)
+            prompt = Template(settings.QUESTIONS_SYSTEM_PROMPT).substitute(
+                {
+                    "report": report.body,
+                    "questions": generate_questions_for_prompt(subscription.questions),
+                }
             )
-            logger.debug(f"Report {report.pk} was accepted by subscription {subscription.pk}")
-        else:
-            logger.debug(f"Report {report.pk} was rejected by subscription {subscription.pk}")
+            result = self.client.extract_data(prompt, Schema)
+
+            is_accepted = all(
+                [getattr(result, field_name) for field_name in result.__pydantic_fields__]
+            )
+            if is_accepted:
+                SubscribedItem.objects.create(
+                    subscription=task.job.subscription,
+                    job=task.job,
+                    report=report,
+                    answers=result.model_dump(),
+                )
+                logger.debug(f"Report {report.pk} was accepted by subscription {subscription.pk}")
+            else:
+                logger.debug(f"Report {report.pk} was rejected by subscription {subscription.pk}")
+        finally:
+            db.close_old_connections()

--- a/radis/subscriptions/processors.py
+++ b/radis/subscriptions/processors.py
@@ -60,7 +60,7 @@ class SubscriptionTaskProcessor(AnalysisTaskProcessor):
             result = self.client.extract_data(prompt, Schema)
 
             is_accepted = all(
-                [getattr(result, field_name) for field_name in result.__pydantic_fields__]
+                getattr(result, field_name) for field_name in result.__pydantic_fields__
             )
             if is_accepted:
                 SubscribedItem.objects.create(
@@ -73,4 +73,4 @@ class SubscriptionTaskProcessor(AnalysisTaskProcessor):
             else:
                 logger.debug(f"Report {report.pk} was rejected by subscription {subscription.pk}")
         finally:
-            db.close_old_connections()
+            db.connections.close_all()


### PR DESCRIPTION
## Summary

- pytest now turns every warning not matching an explicit ignore into a test failure (`"error"` first in `filterwarnings`), so warnings can't silently accumulate.
- The net immediately surfaced a real connection-hygiene bug, fixed here: Django connections are thread-local, and the extraction/subscription processors' executor worker threads never reliably closed theirs — the subscription processor closed them only in the main thread (unreachable for workers), the extraction processor skipped the close on the failure path. Both now close in a `finally` inside the worker thread. Previously each processor run leaked one Postgres connection per worker until garbage collection.
- Test settings disable the periodic `backup_db` task so a suite run crossing its cron time can't fire a real `pg_dump` (dedicated backup coverage lives in adit-radis-shared with the command mocked).

Companion changes to openradx/adit#368 and openradx/adit-radis-shared#215.

## Verification

Full suite in the dev container with warnings-as-errors: **381 passed, 0 warnings, RC=0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)