### PR TITLE
Fix djlint 1.43 template lint errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,8 @@ lint.select = ["E", "F", "I", "DJ", "UP"]
 profile = "django"
 max_line_length = 120
 ignore = "H021,H030,H031,T002"
+# crispy-forms block tag; without this djlint (1.43+) flags {% endspecialspaceless %} as unmatched
+custom_blocks = "specialspaceless"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/radis/extractions/templates/extractions/_extraction_help.html
+++ b/radis/extractions/templates/extractions/_extraction_help.html
@@ -14,13 +14,11 @@
             format for detailed analysis. This process leverages both keyword-based searches
             and a Large Language Model (LLM) to filter and extract relevant information.
         </p>
-        <p>
-            To create a new extraction job, these three steps must be followed:
-            <ol>
-                <li>Search for reports using a keyword-based query and database filters.</li>
-                <li>Define filters that are used by a LLM to further refine the results.</li>
-                <li>Specify the data that the LLM should finally extract from the report.</li>
-            </ol>
-        </p>
+        <p>To create a new extraction job, these three steps must be followed:</p>
+        <ol>
+            <li>Search for reports using a keyword-based query and database filters.</li>
+            <li>Define filters that are used by a LLM to further refine the results.</li>
+            <li>Specify the data that the LLM should finally extract from the report.</li>
+        </ol>
     </div>
 </div>

--- a/radis/search/templates/search/_search_info.html
+++ b/radis/search/templates/search/_search_info.html
@@ -5,15 +5,13 @@
             Provide your search query in the search box above to search for reports. You can use
             additional filters to narrow down the search results (on the right side).
         </p>
-        <p>
-            The following search rules apply:
-            <ul>
-                <li>Search terms are case-insensitive.</li>
-                <li>All terms in a query must be matched by a document (implicit AND query).</li>
-                <li>term1 OR term2 (capital OR) means that either term1 or term2 must match.</li>
-                <li>A phrase surrounded by quotes will look for an exact match, e.g. "lung disease".</li>
-                <li>- in front of a term means that the term or phrase must not be present.</li>
-            </ul>
-        </p>
+        <p>The following search rules apply:</p>
+        <ul>
+            <li>Search terms are case-insensitive.</li>
+            <li>All terms in a query must be matched by a document (implicit AND query).</li>
+            <li>term1 OR term2 (capital OR) means that either term1 or term2 must match.</li>
+            <li>A phrase surrounded by quotes will look for an exact match, e.g. "lung disease".</li>
+            <li>- in front of a term means that the term or phrase must not be present.</li>
+        </ul>
     </div>
 </div>


### PR DESCRIPTION
The Renovate lock-file PR (#250) bumps **djlint 1.40.3 → 1.43.1**, which tightened its rules and now fails CI on three **pre-existing** template issues (`main` is green only because it still runs the old djlint). Fixing them here unblocks #250 and every future Renovate lock refresh.

- **H025** — `<ol>`/`<ul>` nested directly inside a `<p>` in `_extraction_help.html` and `_search_info.html`. A `<p>` cannot legally contain a list (the browser auto-closes the `<p>`), so each list is moved out of its paragraph.
- **T038** — `{% endspecialspaceless %}` reported as an unmatched end tag. `specialspaceless` is a valid **crispy-forms** block tag, so this is a djlint blind spot, not a template bug — registered via `custom_blocks` in `[tool.djlint]`.

Docs/config only, no runtime code touched. Verified locally with the CI version: `djlint 1.43.1 . --lint` → **0 errors**; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured extraction help instructions into clearly separated explanatory text and a numbered step-by-step list.
  * Improved the presentation of search rules by separating introductory text from the rules list for easier reading.
* **Style**
  * Updated template formatting support to ensure custom spacing sections are handled correctly by the formatter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->