### PR TITLE
Fix crash when a job's tasks all end up canceled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Shared utilities come from `adit-radis-shared` package (accounts, token auth, co
 Analysis operations follow a Job -> Task pattern (similar to ADIT):
 
 - An **AnalysisJob** contains multiple **AnalysisTasks**
-- Status flow: `UNVERIFIED` -> `PREPARING` -> `PENDING` -> `IN_PROGRESS` -> `SUCCESS`/`WARNING`/`FAILURE`
+- Status flow: `UNVERIFIED` -> `PREPARING` -> `PENDING` -> `IN_PROGRESS` -> `SUCCESS`/`WARNING`/`FAILURE`/`CANCELED`
 - Jobs automatically update state based on task completion
 - Email notifications sent on job completion
 - Background workers (Procrastinate) process tasks from `default` and `llm` queues

--- a/radis/core/models.py
+++ b/radis/core/models.py
@@ -110,23 +110,32 @@ class AnalysisJob(models.Model):
         has_success = self.tasks.filter(status=AnalysisTask.Status.SUCCESS).exists()
         has_warning = self.tasks.filter(status=AnalysisTask.Status.WARNING).exists()
         has_failure = self.tasks.filter(status=AnalysisTask.Status.FAILURE).exists()
+        has_canceled = self.tasks.filter(status=AnalysisTask.Status.CANCELED).exists()
 
+        # An "All tasks ..." message would be untrue when some tasks were canceled instead.
         if has_failure:
             self.status = AnalysisJob.Status.FAILURE
             self.message = (
-                "Some tasks failed." if (has_success or has_warning) else "All tasks failed."
+                "Some tasks failed."
+                if (has_success or has_warning or has_canceled)
+                else "All tasks failed."
             )
 
         elif has_warning:
             self.status = AnalysisJob.Status.WARNING
             self.message = (
-                "Some tasks have warnings." if has_success else "All tasks have warnings."
+                "Some tasks have warnings."
+                if (has_success or has_canceled)
+                else "All tasks have warnings."
             )
         elif has_success:
             self.status = AnalysisJob.Status.SUCCESS
-            self.message = "All tasks succeeded."
+            self.message = "Some tasks were canceled." if has_canceled else "All tasks succeeded."
+        elif has_canceled:
+            self.status = AnalysisJob.Status.CANCELED
+            self.message = "All tasks were canceled."
         else:
-            # at least one of success, warnings or failures must be > 0
+            # at least one of success, warnings, failures or cancellations must be > 0
             raise AssertionError(f"Invalid task status of {self}.")
 
         self.ended_at = timezone.now()

--- a/radis/core/tests/test_models.py
+++ b/radis/core/tests/test_models.py
@@ -63,6 +63,67 @@ class TestAnalysisJob:
         assert job.ended_at is not None
 
     @pytest.mark.django_db
+    def test_job_update_job_state_all_tasks_canceled(self):
+        # Status is PENDING, not CANCELING, so this reaches the final evaluation, where
+        # an all-canceled job raised AssertionError before the canceled branch existed.
+        user = UserFactory.create()
+        job = ExtractionJobFactory.create(owner=user, status=AnalysisJob.Status.PENDING)
+
+        ExtractionTaskFactory.create(job=job, status=AnalysisTask.Status.CANCELED)
+        ExtractionTaskFactory.create(job=job, status=AnalysisTask.Status.CANCELED)
+
+        result = job.update_job_state()
+        job.refresh_from_db()
+
+        assert result is True
+        assert job.status == AnalysisJob.Status.CANCELED
+        assert job.message == "All tasks were canceled."
+        assert job.ended_at is not None
+
+    @pytest.mark.django_db
+    def test_job_update_job_state_canceled_task_does_not_mask_failure(self):
+        # The canceled branch is last in the chain, so it must not shadow a failure.
+        user = UserFactory.create()
+        job = ExtractionJobFactory.create(owner=user, status=AnalysisJob.Status.PENDING)
+
+        ExtractionTaskFactory.create(job=job, status=AnalysisTask.Status.CANCELED)
+        ExtractionTaskFactory.create(job=job, status=AnalysisTask.Status.FAILURE)
+
+        job.update_job_state()
+        job.refresh_from_db()
+
+        assert job.status == AnalysisJob.Status.FAILURE
+        assert job.message == "Some tasks failed."
+
+    @pytest.mark.django_db
+    def test_job_update_job_state_success_and_canceled_does_not_claim_all_succeeded(self):
+        user = UserFactory.create()
+        job = ExtractionJobFactory.create(owner=user, status=AnalysisJob.Status.PENDING)
+
+        ExtractionTaskFactory.create(job=job, status=AnalysisTask.Status.SUCCESS)
+        ExtractionTaskFactory.create(job=job, status=AnalysisTask.Status.CANCELED)
+
+        job.update_job_state()
+        job.refresh_from_db()
+
+        assert job.status == AnalysisJob.Status.SUCCESS
+        assert job.message == "Some tasks were canceled."
+
+    @pytest.mark.django_db
+    def test_job_update_job_state_warning_and_canceled_does_not_claim_all_warned(self):
+        user = UserFactory.create()
+        job = ExtractionJobFactory.create(owner=user, status=AnalysisJob.Status.PENDING)
+
+        ExtractionTaskFactory.create(job=job, status=AnalysisTask.Status.WARNING)
+        ExtractionTaskFactory.create(job=job, status=AnalysisTask.Status.CANCELED)
+
+        job.update_job_state()
+        job.refresh_from_db()
+
+        assert job.status == AnalysisJob.Status.WARNING
+        assert job.message == "Some tasks have warnings."
+
+    @pytest.mark.django_db
     def test_job_update_job_state_tasks_still_pending(self):
         user = UserFactory.create()
         job = ExtractionJobFactory.create(owner=user, status=AnalysisJob.Status.PENDING)
@@ -380,16 +441,6 @@ class TestAnalysisJob:
         job = ExtractionJobFactory.create(owner=user)
         context = job.get_mail_context()
         assert context == {}  # Default implementation returns empty dict
-
-    @pytest.mark.django_db
-    def test_job_update_job_state_with_only_canceled_tasks(self):
-        user = UserFactory.create()
-        job = ExtractionJobFactory.create(owner=user, status=AnalysisJob.Status.PENDING)
-        ExtractionTaskFactory.create(job=job, status=AnalysisTask.Status.CANCELED)
-        ExtractionTaskFactory.create(job=job, status=AnalysisTask.Status.CANCELED)
-
-        with pytest.raises(AssertionError, match="Invalid task status"):
-            job.update_job_state()
 
     @pytest.mark.django_db
     def test_job_update_job_state_consecutive_calls(self):


### PR DESCRIPTION
Mirrors openradx/adit#387 — RADIS has the identical bug.

**Bug:** `update_job_state()` derives a finished job's status from success/warning/failure tasks. A job whose tasks are **all canceled** matches no branch and hits `raise AssertionError`. Reproduced on current main.

**Fix:** a canceled branch, placed **last** so it only applies when no success, warning or failure task exists.

**Also:** a job with one succeeded + one canceled task reported *"All tasks succeeded."* — untrue, and for an analysis job misleading. The existing *"Some tasks ..."* wording is now used whenever canceled tasks are present. Statuses are unchanged; only messages.

**Note:** removes `test_job_update_job_state_with_only_canceled_tasks`, added in #147, which asserted the crash was *correct* behaviour (`pytest.raises(AssertionError)`). The scenario is now covered with the expected outcome instead. Worth knowing the crash was observable in the suite since Nov 2025.

**Tests:** 4 added (all-canceled; canceled must not mask a failure; and the two message cases). Full suite: 621 passed, ruff + pyright clean.

⚠️ Overlaps #256, which edits the same function (top and save). Whichever lands first, the other needs a rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added canceled as a terminal status for jobs and tasks.
  - Job results now accurately reflect canceled tasks, including mixed outcomes and jobs where all tasks are canceled.

- **Bug Fixes**
  - Improved status and message reporting when cancellations occur alongside successes, warnings, or failures.

- **Tests**
  - Added coverage for canceled-task scenarios and mixed job outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->