### PR TITLE
Bump adit-radis-shared to 0.26.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.25.0",
+    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.26.0",
     "adrf>=0.1.9",
     "aiofiles>=24.1.0",
     "asyncinotify>=4.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ constraints = [{ name = "autobahn", specifier = "<25.11.1" }]
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.25.0#793b48e440678968e8a933049113045c2f6a126f" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.26.0#d46611ff80d4fece27aaa946a994e18d9c69156f" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },
@@ -2843,7 +2843,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.25.0" },
+    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.26.0" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },


### PR DESCRIPTION
Picks up [0.26.0](https://github.com/openradx/adit-radis-shared/releases/tag/0.26.0).

The motivating change is openradx/adit-radis-shared#231: `compose-down` passes `--remove-orphans`. #267 removed the local wrapper that did this, so on `main` the flag is currently absent and `docs/maintenance.md` describes behaviour that does not happen. This restores it:

```
$ SIMULATE=true uv run cli compose-down
Simulating: docker compose ... -p radis_dev down --remove-orphans
```

Also included, from the same release: a configurable Postgres startup wait, `.env` passthrough to the app containers via `env_file`, and a cryptography security update.

704 tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXPHZrTzdGdHmNv6ZTEDJN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shared application components to the latest compatible version.
  * No changes to publicly available features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->