### PR TITLE
Give the explicit cleanup commands in the maintenance docs

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -24,18 +24,24 @@ RADIS sends all inference to the endpoint in `LLM_BASE_URL` and runs no inferenc
 its own. Docker keeps containers and Swarm services that the compose files do not define,
 so a deployment that still runs one needs it cleaned up by hand.
 
-**Production (Docker Swarm)**: `stack-deploy` does not pass `--prune`. Check for an
-inference service and remove it, along with the model cache it holds:
+**Development**: pass `--remove-orphans`, which removes containers of this project that
+the compose files no longer define:
+
+```terminal
+uv run cli compose-down -- --remove-orphans
+```
+
+A model cache volume outlives them and can be reclaimed with
+`docker volume rm radis_dev_models_data`.
+
+**Production (Docker Swarm)**: `stack-deploy` does not prune, so a service that has left
+the compose files keeps running. Find it and remove it, along with the model cache it holds:
 
 ```terminal
 docker service ls | grep llm          # e.g. radis_llm_gpu
 docker service rm radis_llm_gpu       # use your stack name if it is not 'radis'
 docker volume rm radis_models_data    # on each node that holds model files
 ```
-
-**Development**: `uv run cli compose-down` passes `--remove-orphans` and clears such
-containers out. A model cache volume outlives them and can be reclaimed with
-`docker volume rm radis_dev_models_data`.
 
 ## Search language configs
 


### PR DESCRIPTION
`docs/maintenance.md` told the reader what `compose-down` does rather than what to type:

> **Development**: `uv run cli compose-down` passes `--remove-orphans` and clears such containers out.

That ties the docs to whichever version of the shared CLI is pinned. openradx/adit-radis-shared#232 leaves the flag to the caller, at which point the sentence becomes wrong — and this is exactly the page someone reads while cleaning up a stale inference container.

It now gives the command:

```terminal
uv run cli compose-down -- --remove-orphans
```

Verified against the pinned 0.26.0, which still adds the flag itself: passing it explicitly produces `down --remove-orphans` once, not twice. So this reads correctly both now and after the next bump.

### Not changed

The production section still shows the manual `docker service ls` / `docker service rm` steps rather than `stack-deploy -- --prune`. That flag needs #232 released, and against the pinned version it fails:

```
$ uv run cli stack-deploy -- --prune
Error: Got unexpected extra argument(s) (--prune)
```

Worth revisiting when RADIS takes that release.

`mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXPHZrTzdGdHmNv6ZTEDJN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated maintenance guidance to include development orphan cleanup before production cleanup.
  * Clarified how to remove orphaned services and noted that production deployments do not automatically remove obsolete services.
  * Retained instructions for removing the model cache volume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->