### PR TITLE
Bump adit-radis-shared to 0.27.0

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -24,18 +24,31 @@ RADIS sends all inference to the endpoint in `LLM_BASE_URL` and runs no inferenc
 its own. Docker keeps containers and Swarm services that the compose files do not define,
 so a deployment that still runs one needs it cleaned up by hand.
 
-**Production (Docker Swarm)**: `stack-deploy` does not pass `--prune`. Check for an
-inference service and remove it, along with the model cache it holds:
+**Development**: pass `--remove-orphans`, which removes containers of this project that
+the compose files no longer define:
+
+```terminal
+uv run cli compose-down -- --remove-orphans
+```
+
+A model cache volume outlives them and can be reclaimed with
+`docker volume rm radis_dev_models_data`.
+
+**Production (Docker Swarm)**: pass `--prune`, which removes services the deployment no
+longer declares. Only do so when deploying the complete set of compose files, since Swarm
+removes every service the deployment does not mention:
+
+```terminal
+uv run cli stack-deploy -- --prune
+```
+
+To look first, or to clean up without redeploying:
 
 ```terminal
 docker service ls | grep llm          # e.g. radis_llm_gpu
 docker service rm radis_llm_gpu       # use your stack name if it is not 'radis'
 docker volume rm radis_models_data    # on each node that holds model files
 ```
-
-**Development**: `uv run cli compose-down` passes `--remove-orphans` and clears such
-containers out. A model cache volume outlives them and can be reclaimed with
-`docker volume rm radis_dev_models_data`.
 
 ## Search language configs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.26.0",
+    "adit-radis-shared @ git+https://github.com/openradx/adit-radis-shared.git@0.27.0",
     "adrf>=0.1.9",
     "aiofiles>=24.1.0",
     "asyncinotify>=4.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ constraints = [{ name = "autobahn", specifier = "<25.11.1" }]
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.26.0#d46611ff80d4fece27aaa946a994e18d9c69156f" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?rev=0.27.0#b081ea48fc250b0a6ad9a5c8e852dd6ddeeaf2b0" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },
@@ -2843,7 +2843,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.26.0" },
+    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?rev=0.27.0" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },


### PR DESCRIPTION
Picks up [0.27.0](https://github.com/openradx/adit-radis-shared/releases/tag/0.27.0), where the CLI passes arguments through to the underlying commands rather than deciding options itself (openradx/adit-radis-shared#232).

Two behaviour changes reach RADIS:

- `compose-down` no longer adds `--remove-orphans` on its own — pass it when you want it
- `stack-deploy` accepts arguments, so `-- --prune` works

```
$ SIMULATE=true uv run cli compose-down
Simulating: docker compose ... down

$ SIMULATE=true uv run cli compose-down -- --remove-orphans
Simulating: docker compose ... down --remove-orphans

$ SIMULATE=true uv run cli stack-deploy -- --prune
Simulating: docker stack deploy --detach  --prune -c ... -c ... radis_prod
```

### Docs

`docs/maintenance.md` described what `compose-down` does, which tied it to the pinned version. It now gives the commands:

- **Development**: `uv run cli compose-down -- --remove-orphans`
- **Production**: `uv run cli stack-deploy -- --prune`, with the warning that Swarm removes every service the deployment does not declare, plus the manual `docker service rm` steps for looking first or cleaning up without redeploying

This supersedes #269, which carried the development half against the old pin — that one can be closed. The production half needed this release, since `stack-deploy -- --prune` errors on 0.26.0.

704 tests pass; lint and `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXPHZrTzdGdHmNv6ZTEDJN