### PR TITLE
Raise hnsw.ef_search to cover the vector top-K in hybrid search

### DIFF
--- a/radis/pgsearch/apps.py
+++ b/radis/pgsearch/apps.py
@@ -172,8 +172,9 @@ def register_app():
             name="PG Search",
             search=search,
             # Deliberate cap on how many fused RRF results are paginated for
-            # viewing — not the true union size.
-            max_results=max(settings.HYBRID_VECTOR_TOP_K, settings.HYBRID_FTS_MAX_RESULTS),
+            # viewing — not the true union size (the vector side can add up to
+            # a beam pass of semantic-only results beyond the FTS matches).
+            max_results=settings.HYBRID_FTS_MAX_RESULTS,
         )
     )
 

--- a/radis/pgsearch/providers.py
+++ b/radis/pgsearch/providers.py
@@ -392,8 +392,8 @@ def _fuse_hybrid(search: Search, caller: str) -> _FusedHybrid:
         vec_qs = _exclude_negations(vec_qs, search.query, configs)
         # hnsw.ef_search must cover this slice and hnsw.iterative_scan keeps the
         # post-scan group/language filters from starving it; both ride along as
-        # connection options on every Django connection (see
-        # settings.HYBRID_HNSW_EF_SEARCH).
+        # connection options derived from HYBRID_VECTOR_TOP_K (see the DATABASES
+        # options in settings).
         vec_rows = list(
             vec_qs.distinct()
             .exclude(embedding__isnull=True)

--- a/radis/pgsearch/providers.py
+++ b/radis/pgsearch/providers.py
@@ -9,7 +9,6 @@ import openai
 from django.conf import settings
 from django.contrib.postgres.search import SearchHeadline, SearchQuery, SearchRank
 from django.core.cache import cache
-from django.db import connection, transaction
 from django.db.models import Case, F, FloatField, Q, TextField, Value, When
 from pgvector.django import CosineDistance
 
@@ -391,29 +390,17 @@ def _fuse_hybrid(search: Search, caller: str) -> _FusedHybrid:
     if query_vec is not None:
         vec_qs = ReportSearchIndex.objects.filter(filter_query)
         vec_qs = _exclude_negations(vec_qs, search.query, configs)
-        # hnsw.ef_search bounds how many rows one HNSW index scan can emit, so it
-        # must cover the slice taken below or the scan returns far fewer candidates
-        # than asked for. The group/language filters are applied after the scan,
-        # which can starve the candidate list further; iterative_scan resumes the
-        # scan until the LIMIT is satisfied, and strict_order keeps emission
-        # ordered by distance, which the (distance, report_id) ORDER BY relies on
-        # (Incremental Sort over the scan's presorted key). set_config(..., true)
-        # is transaction-scoped, so neither setting leaks to later queries on the
-        # connection.
-        with transaction.atomic():
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    "SELECT set_config('hnsw.ef_search', %s, true), "
-                    "set_config('hnsw.iterative_scan', 'strict_order', true)",
-                    [str(settings.HYBRID_HNSW_EF_SEARCH)],
-                )
-            vec_rows = list(
-                vec_qs.distinct()
-                .exclude(embedding__isnull=True)
-                .annotate(distance=CosineDistance("embedding", query_vec))
-                .order_by("distance", "report_id")
-                .values_list("report_id", "distance")[: settings.HYBRID_VECTOR_TOP_K]
-            )
+        # hnsw.ef_search must cover this slice and hnsw.iterative_scan keeps the
+        # post-scan group/language filters from starving it; both ride along as
+        # connection options on every Django connection (see
+        # settings.HYBRID_HNSW_EF_SEARCH).
+        vec_rows = list(
+            vec_qs.distinct()
+            .exclude(embedding__isnull=True)
+            .annotate(distance=CosineDistance("embedding", query_vec))
+            .order_by("distance", "report_id")
+            .values_list("report_id", "distance")[: settings.HYBRID_VECTOR_TOP_K]
+        )
         for i, (rid, dist) in enumerate(vec_rows):
             vec_rank[rid] = i + 1
             vec_distance[rid] = float(dist)

--- a/radis/pgsearch/providers.py
+++ b/radis/pgsearch/providers.py
@@ -390,18 +390,21 @@ def _fuse_hybrid(search: Search, caller: str) -> _FusedHybrid:
     if query_vec is not None:
         vec_qs = ReportSearchIndex.objects.filter(filter_query)
         vec_qs = _exclude_negations(vec_qs, search.query, configs)
-        # One pass over the corpus-wide nearest neighbours: hnsw.ef_search rides
-        # along as a connection option derived from HYBRID_VECTOR_TOP_K (see the
-        # DATABASES options in settings) so the scan can emit the whole slice.
-        # The filters above then shrink it — the vector candidates are the
-        # accessible subset of the corpus's TOP_K nearest, deliberately not
-        # topped back up by an iterative scan.
+        # One pass over the corpus-wide nearest neighbours: the scan emits at
+        # most ~hnsw.ef_search rows (a connection option, see
+        # settings.HYBRID_HNSW_EF_SEARCH), and the filters above then shrink
+        # them — the semantic candidates are the accessible subset of roughly
+        # the ef_search nearest reports, deliberately not topped back up by an
+        # iterative scan. The slice is a planner guard, not a semantic cap:
+        # sized above any beam emission (~1.45x ef_search measured) so it never
+        # truncates the pass, while keeping a LIMIT in the query — without one
+        # the planner abandons the index for a full sequential sort.
         vec_rows = list(
             vec_qs.distinct()
             .exclude(embedding__isnull=True)
             .annotate(distance=CosineDistance("embedding", query_vec))
             .order_by("distance", "report_id")
-            .values_list("report_id", "distance")[: settings.HYBRID_VECTOR_TOP_K]
+            .values_list("report_id", "distance")[: settings.HYBRID_HNSW_EF_SEARCH * 2]
         )
         for i, (rid, dist) in enumerate(vec_rows):
             vec_rank[rid] = i + 1
@@ -428,13 +431,10 @@ def _fuse_hybrid(search: Search, caller: str) -> _FusedHybrid:
     ordered_pairs = rrf_fuse(vec_rank, fts_rank, k=settings.HYBRID_RRF_K)
     rrf_score_by_id = dict(ordered_pairs)
     ordered_ids = list(rrf_score_by_id)
+    # The vector half is one complete beam pass by definition, so it never makes
+    # the union a lower bound; only a truncated FTS side does.
     total_relation: Literal["exact", "at_least", "approximately"] = (
-        "at_least"
-        if (
-            len(fts_rows) >= settings.HYBRID_FTS_MAX_RESULTS
-            or len(vec_rank) >= settings.HYBRID_VECTOR_TOP_K
-        )
-        else "exact"
+        "at_least" if len(fts_rows) >= settings.HYBRID_FTS_MAX_RESULTS else "exact"
     )
     return _FusedHybrid(
         ordered_ids=ordered_ids,

--- a/radis/pgsearch/providers.py
+++ b/radis/pgsearch/providers.py
@@ -390,10 +390,12 @@ def _fuse_hybrid(search: Search, caller: str) -> _FusedHybrid:
     if query_vec is not None:
         vec_qs = ReportSearchIndex.objects.filter(filter_query)
         vec_qs = _exclude_negations(vec_qs, search.query, configs)
-        # hnsw.ef_search must cover this slice and hnsw.iterative_scan keeps the
-        # post-scan group/language filters from starving it; both ride along as
-        # connection options derived from HYBRID_VECTOR_TOP_K (see the DATABASES
-        # options in settings).
+        # One pass over the corpus-wide nearest neighbours: hnsw.ef_search rides
+        # along as a connection option derived from HYBRID_VECTOR_TOP_K (see the
+        # DATABASES options in settings) so the scan can emit the whole slice.
+        # The filters above then shrink it — the vector candidates are the
+        # accessible subset of the corpus's TOP_K nearest, deliberately not
+        # topped back up by an iterative scan.
         vec_rows = list(
             vec_qs.distinct()
             .exclude(embedding__isnull=True)

--- a/radis/pgsearch/providers.py
+++ b/radis/pgsearch/providers.py
@@ -9,6 +9,7 @@ import openai
 from django.conf import settings
 from django.contrib.postgres.search import SearchHeadline, SearchQuery, SearchRank
 from django.core.cache import cache
+from django.db import connection, transaction
 from django.db.models import Case, F, FloatField, Q, TextField, Value, When
 from pgvector.django import CosineDistance
 
@@ -390,13 +391,29 @@ def _fuse_hybrid(search: Search, caller: str) -> _FusedHybrid:
     if query_vec is not None:
         vec_qs = ReportSearchIndex.objects.filter(filter_query)
         vec_qs = _exclude_negations(vec_qs, search.query, configs)
-        vec_rows = list(
-            vec_qs.distinct()
-            .exclude(embedding__isnull=True)
-            .annotate(distance=CosineDistance("embedding", query_vec))
-            .order_by("distance", "report_id")
-            .values_list("report_id", "distance")[: settings.HYBRID_VECTOR_TOP_K]
-        )
+        # hnsw.ef_search bounds how many rows one HNSW index scan can emit, so it
+        # must cover the slice taken below or the scan returns far fewer candidates
+        # than asked for. The group/language filters are applied after the scan,
+        # which can starve the candidate list further; iterative_scan resumes the
+        # scan until the LIMIT is satisfied, and strict_order keeps emission
+        # ordered by distance, which the (distance, report_id) ORDER BY relies on
+        # (Incremental Sort over the scan's presorted key). set_config(..., true)
+        # is transaction-scoped, so neither setting leaks to later queries on the
+        # connection.
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT set_config('hnsw.ef_search', %s, true), "
+                    "set_config('hnsw.iterative_scan', 'strict_order', true)",
+                    [str(settings.HYBRID_HNSW_EF_SEARCH)],
+                )
+            vec_rows = list(
+                vec_qs.distinct()
+                .exclude(embedding__isnull=True)
+                .annotate(distance=CosineDistance("embedding", query_vec))
+                .order_by("distance", "report_id")
+                .values_list("report_id", "distance")[: settings.HYBRID_VECTOR_TOP_K]
+            )
         for i, (rid, dist) in enumerate(vec_rows):
             vec_rank[rid] = i + 1
             vec_distance[rid] = float(dist)

--- a/radis/pgsearch/tests/test_provider_hybrid.py
+++ b/radis/pgsearch/tests/test_provider_hybrid.py
@@ -503,6 +503,11 @@ def test_connection_carries_hnsw_gucs(db, settings):
     connection without these options silently truncates the vector half of the
     hybrid fusion."""
     with connection.cursor() as cursor:
+        # Force pgvector's library to load: hnsw.iterative_scan below is only
+        # defined once it has, since it is not in the connection options and a
+        # connection that has run no vector operation yet would error the SHOW
+        # with "unrecognized configuration parameter".
+        cursor.execute("SELECT '[1]'::vector(1)")
         cursor.execute("SHOW hnsw.ef_search")
         # Restates the derivation on purpose: ef_search must track the top-K
         # slice, never diverge from it.

--- a/radis/pgsearch/tests/test_provider_hybrid.py
+++ b/radis/pgsearch/tests/test_provider_hybrid.py
@@ -496,12 +496,12 @@ def test_openai_rate_limit_error_in_retrieve_falls_back_to_fts(group, reports_wi
 
 
 def test_connection_carries_hnsw_gucs(db, settings):
-    """hnsw.ef_search and hnsw.iterative_scan ride along as libpq connection
-    options (settings.DATABASES), so every Django connection runs the same
-    vector-scan configuration. ef_search must cover the vector top-K slice —
+    """hnsw.ef_search rides along as a libpq connection option
+    (settings.DATABASES), so every Django connection runs the same vector-scan
+    configuration. It directly governs the depth of the semantic side —
     pgvector's default of 40 caps how many rows one HNSW index scan emits, so a
-    connection without these options silently truncates the vector half of the
-    hybrid fusion."""
+    connection without the option quietly runs the vector half of the hybrid
+    fusion at a fraction of the configured depth."""
     with connection.cursor() as cursor:
         # Force pgvector's library to load: hnsw.iterative_scan below is only
         # defined once it has, since it is not in the connection options and a
@@ -509,9 +509,7 @@ def test_connection_carries_hnsw_gucs(db, settings):
         # with "unrecognized configuration parameter".
         cursor.execute("SELECT '[1]'::vector(1)")
         cursor.execute("SHOW hnsw.ef_search")
-        # Restates the derivation on purpose: ef_search must track the top-K
-        # slice, never diverge from it.
-        assert cursor.fetchone()[0] == str(max(settings.HYBRID_VECTOR_TOP_K, 40))
+        assert cursor.fetchone()[0] == str(settings.HYBRID_HNSW_EF_SEARCH)
         # One-pass semantics is deliberate: TOP_K caps the vector candidates and
         # the filters may shrink the list below it — the scan must not resume to
         # top it back up.

--- a/radis/pgsearch/tests/test_provider_hybrid.py
+++ b/radis/pgsearch/tests/test_provider_hybrid.py
@@ -3,7 +3,9 @@ from unittest.mock import patch
 
 import pytest
 from django.contrib.auth.models import Group
+from django.db import connection
 from django.test import override_settings
+from django.test.utils import CaptureQueriesContext
 
 from radis.core.utils.embedding_client import EmbeddingClientError
 from radis.core.utils.model_spec import parse_model_spec
@@ -492,3 +494,22 @@ def test_openai_rate_limit_error_in_retrieve_falls_back_to_fts(group, reports_wi
 
     # No exception escaped; FTS-only retrieve returned something.
     assert result is not None
+
+
+def test_vector_query_sets_hnsw_gucs(group, reports_with_embeddings, settings):
+    """The vector side must raise hnsw.ef_search to cover the TOP_K slice
+    (pgvector's default of 40 caps how many rows one index scan emits) and turn
+    on strict-order iterative scan so post-scan filters cannot starve the
+    candidate list. Both are transaction-scoped."""
+    dim = settings.EMBEDDINGS_DIM
+    with patch("radis.pgsearch.providers.EmbeddingClient") as MockClient:
+        MockClient.return_value.__enter__.return_value = MockClient.return_value
+        MockClient.return_value.__exit__.return_value = None
+        MockClient.return_value.embed_query.return_value = _unit_vec(0, dim)
+        with CaptureQueriesContext(connection) as ctx:
+            search(_make_search("pneumothorax", group.pk))
+
+    guc_queries = [q["sql"] for q in ctx.captured_queries if "hnsw.ef_search" in q["sql"]]
+    assert len(guc_queries) == 1
+    assert str(settings.HYBRID_HNSW_EF_SEARCH) in guc_queries[0]
+    assert "strict_order" in guc_queries[0]

--- a/radis/pgsearch/tests/test_provider_hybrid.py
+++ b/radis/pgsearch/tests/test_provider_hybrid.py
@@ -504,6 +504,8 @@ def test_connection_carries_hnsw_gucs(db, settings):
     hybrid fusion."""
     with connection.cursor() as cursor:
         cursor.execute("SHOW hnsw.ef_search")
-        assert cursor.fetchone()[0] == str(settings.HYBRID_HNSW_EF_SEARCH)
+        # Restates the derivation on purpose: ef_search must track the top-K
+        # slice (clamped to the server's 1..1000 range), never diverge from it.
+        assert cursor.fetchone()[0] == str(min(max(settings.HYBRID_VECTOR_TOP_K, 40), 1000))
         cursor.execute("SHOW hnsw.iterative_scan")
         assert cursor.fetchone()[0] == "strict_order"

--- a/radis/pgsearch/tests/test_provider_hybrid.py
+++ b/radis/pgsearch/tests/test_provider_hybrid.py
@@ -5,7 +5,6 @@ import pytest
 from django.contrib.auth.models import Group
 from django.db import connection
 from django.test import override_settings
-from django.test.utils import CaptureQueriesContext
 
 from radis.core.utils.embedding_client import EmbeddingClientError
 from radis.core.utils.model_spec import parse_model_spec
@@ -496,20 +495,15 @@ def test_openai_rate_limit_error_in_retrieve_falls_back_to_fts(group, reports_wi
     assert result is not None
 
 
-def test_vector_query_sets_hnsw_gucs(group, reports_with_embeddings, settings):
-    """The vector side must raise hnsw.ef_search to cover the TOP_K slice
-    (pgvector's default of 40 caps how many rows one index scan emits) and turn
-    on strict-order iterative scan so post-scan filters cannot starve the
-    candidate list. Both are transaction-scoped."""
-    dim = settings.EMBEDDINGS_DIM
-    with patch("radis.pgsearch.providers.EmbeddingClient") as MockClient:
-        MockClient.return_value.__enter__.return_value = MockClient.return_value
-        MockClient.return_value.__exit__.return_value = None
-        MockClient.return_value.embed_query.return_value = _unit_vec(0, dim)
-        with CaptureQueriesContext(connection) as ctx:
-            search(_make_search("pneumothorax", group.pk))
-
-    guc_queries = [q["sql"] for q in ctx.captured_queries if "hnsw.ef_search" in q["sql"]]
-    assert len(guc_queries) == 1
-    assert str(settings.HYBRID_HNSW_EF_SEARCH) in guc_queries[0]
-    assert "strict_order" in guc_queries[0]
+def test_connection_carries_hnsw_gucs(db, settings):
+    """hnsw.ef_search and hnsw.iterative_scan ride along as libpq connection
+    options (settings.DATABASES), so every Django connection runs the same
+    vector-scan configuration. ef_search must cover the vector top-K slice —
+    pgvector's default of 40 caps how many rows one HNSW index scan emits, so a
+    connection without these options silently truncates the vector half of the
+    hybrid fusion."""
+    with connection.cursor() as cursor:
+        cursor.execute("SHOW hnsw.ef_search")
+        assert cursor.fetchone()[0] == str(settings.HYBRID_HNSW_EF_SEARCH)
+        cursor.execute("SHOW hnsw.iterative_scan")
+        assert cursor.fetchone()[0] == "strict_order"

--- a/radis/pgsearch/tests/test_provider_hybrid.py
+++ b/radis/pgsearch/tests/test_provider_hybrid.py
@@ -505,7 +505,10 @@ def test_connection_carries_hnsw_gucs(db, settings):
     with connection.cursor() as cursor:
         cursor.execute("SHOW hnsw.ef_search")
         # Restates the derivation on purpose: ef_search must track the top-K
-        # slice (clamped to the server's 1..1000 range), never diverge from it.
-        assert cursor.fetchone()[0] == str(min(max(settings.HYBRID_VECTOR_TOP_K, 40), 1000))
+        # slice, never diverge from it.
+        assert cursor.fetchone()[0] == str(max(settings.HYBRID_VECTOR_TOP_K, 40))
+        # One-pass semantics is deliberate: TOP_K caps the vector candidates and
+        # the filters may shrink the list below it — the scan must not resume to
+        # top it back up.
         cursor.execute("SHOW hnsw.iterative_scan")
-        assert cursor.fetchone()[0] == "strict_order"
+        assert cursor.fetchone()[0] == "off"

--- a/radis/settings/base.py
+++ b/radis/settings/base.py
@@ -530,9 +530,14 @@ EMBEDDINGS_TASK_MAX_ATTEMPTS = 5
 EMBEDDINGS_TASK_EXPONENTIAL_WAIT_SECONDS = 6
 
 # Hybrid search tuning
-HYBRID_VECTOR_TOP_K = 100
+HYBRID_VECTOR_TOP_K = 500
 HYBRID_FTS_MAX_RESULTS = 10_000
 HYBRID_RRF_K = 60
+# pgvector's hnsw.ef_search (default 40) is both the recall knob and a hard cap on
+# the rows a single HNSW index scan emits, so it must at least match the slice the
+# vector retriever takes; anything lower silently truncates the vector half of the
+# fusion to ~ef_search candidates. The server rejects values above 1000.
+HYBRID_HNSW_EF_SEARCH = max(HYBRID_VECTOR_TOP_K, 40)
 
 # Chat
 CHAT_GENERATE_TITLE_SYSTEM_PROMPT = """

--- a/radis/settings/base.py
+++ b/radis/settings/base.py
@@ -538,6 +538,17 @@ HYBRID_RRF_K = 60
 # vector retriever takes; anything lower silently truncates the vector half of the
 # fusion to ~ef_search candidates. The server rejects values above 1000.
 HYBRID_HNSW_EF_SEARCH = max(HYBRID_VECTOR_TOP_K, 40)
+# Applied as libpq connection options rather than as a database- or server-level
+# default: the app carries the setting into every environment it connects to (dev,
+# tests, CI, a restored or externally managed database), and max() above keeps it
+# coupled to the slice it must cover — both would silently drift if the value lived
+# in the database or the compose file. iterative_scan resumes a filtered scan (the
+# group/language filters apply after the index scan) until the LIMIT is satisfied;
+# strict_order keeps emission ordered by distance, which the (distance, report_id)
+# ORDER BY relies on (Incremental Sort over the scan's presorted key).
+DATABASES["default"].setdefault("OPTIONS", {})["options"] = (
+    f"-c hnsw.ef_search={HYBRID_HNSW_EF_SEARCH} -c hnsw.iterative_scan=strict_order"
+)
 
 # Chat
 CHAT_GENERATE_TITLE_SYSTEM_PROMPT = """

--- a/radis/settings/base.py
+++ b/radis/settings/base.py
@@ -533,25 +533,34 @@ EMBEDDINGS_TASK_EXPONENTIAL_WAIT_SECONDS = 6
 HYBRID_VECTOR_TOP_K = _optional_env("HYBRID_VECTOR_TOP_K", int, 500)
 HYBRID_FTS_MAX_RESULTS = 10_000
 HYBRID_RRF_K = 60
-# pgvector's hnsw.ef_search (default 40) is both the recall knob and a hard cap on
-# the rows a single HNSW index scan emits, so it is derived from the top-K slice
-# instead of being its own setting — an independently configured value could drift
-# below the slice and silently truncate the vector half of the fusion to
-# ~ef_search candidates. Clamped to the server's 1..1000 range, because an
-# out-of-range connect-time value fails GUC validation and would put the scan
-# back at the default; depth past 1000 still works, as strict-order iterative
-# scan resumes the scan until the LIMIT is satisfied — which is also what keeps
-# the post-scan group/language filters from starving the candidate list, while
-# preserving the distance ordering the (distance, report_id) ORDER BY relies on
-# (Incremental Sort over the scan's presorted key).
+# HYBRID_VECTOR_TOP_K caps the vector half of the fusion; it is not a quota. The
+# HNSW scan makes one pass over the corpus-wide nearest neighbours and the
+# group/language/negation filters then shrink those candidates, so the semantic
+# list is the accessible subset of the corpus's TOP_K nearest and may be shorter
+# than TOP_K. Deliberately no iterative scan to top the list back up: one uniform
+# relevance bar for every group, and one bounded pass instead of digging through
+# up to hnsw.max_scan_tuples inaccessible neighbours under a selective filter.
+#
+# pgvector's hnsw.ef_search (default 40) is both the recall knob and a hard cap
+# on the rows that single pass emits, so it is derived from the top-K slice
+# instead of being its own setting — an independently configured value could
+# drift below the slice and silently truncate the vector half to ~ef_search
+# candidates. The server rejects values above 1000, which therefore also bounds
+# the top-K a single pass can deliver — checked here so a bigger value is a boot
+# error naming the setting, not a silently under-filled slice.
 #
 # Attached as libpq connection options rather than as a database- or server-level
 # default, so the app carries the setting into every environment it connects to
 # (dev, tests, CI, a restored database); production.py extends this dict the same
 # way for the database password.
+if not 1 <= HYBRID_VECTOR_TOP_K <= 1000:
+    raise ImproperlyConfigured(
+        f"HYBRID_VECTOR_TOP_K={HYBRID_VECTOR_TOP_K} must be between 1 and 1000: a "
+        "single HNSW pass cannot emit more rows than hnsw.ef_search, whose server "
+        "maximum is 1000."
+    )
 DATABASES["default"].setdefault("OPTIONS", {})["options"] = (
-    f"-c hnsw.ef_search={min(max(HYBRID_VECTOR_TOP_K, 40), 1000)} "
-    "-c hnsw.iterative_scan=strict_order"
+    f"-c hnsw.ef_search={max(HYBRID_VECTOR_TOP_K, 40)}"
 )
 
 # Chat

--- a/radis/settings/base.py
+++ b/radis/settings/base.py
@@ -530,24 +530,28 @@ EMBEDDINGS_TASK_MAX_ATTEMPTS = 5
 EMBEDDINGS_TASK_EXPONENTIAL_WAIT_SECONDS = 6
 
 # Hybrid search tuning
-HYBRID_VECTOR_TOP_K = 500
+HYBRID_VECTOR_TOP_K = _optional_env("HYBRID_VECTOR_TOP_K", int, 500)
 HYBRID_FTS_MAX_RESULTS = 10_000
 HYBRID_RRF_K = 60
 # pgvector's hnsw.ef_search (default 40) is both the recall knob and a hard cap on
-# the rows a single HNSW index scan emits, so it must at least match the slice the
-# vector retriever takes; anything lower silently truncates the vector half of the
-# fusion to ~ef_search candidates. The server rejects values above 1000.
-HYBRID_HNSW_EF_SEARCH = max(HYBRID_VECTOR_TOP_K, 40)
-# Applied as libpq connection options rather than as a database- or server-level
-# default: the app carries the setting into every environment it connects to (dev,
-# tests, CI, a restored or externally managed database), and max() above keeps it
-# coupled to the slice it must cover — both would silently drift if the value lived
-# in the database or the compose file. iterative_scan resumes a filtered scan (the
-# group/language filters apply after the index scan) until the LIMIT is satisfied;
-# strict_order keeps emission ordered by distance, which the (distance, report_id)
-# ORDER BY relies on (Incremental Sort over the scan's presorted key).
+# the rows a single HNSW index scan emits, so it is derived from the top-K slice
+# instead of being its own setting — an independently configured value could drift
+# below the slice and silently truncate the vector half of the fusion to
+# ~ef_search candidates. Clamped to the server's 1..1000 range, because an
+# out-of-range connect-time value fails GUC validation and would put the scan
+# back at the default; depth past 1000 still works, as strict-order iterative
+# scan resumes the scan until the LIMIT is satisfied — which is also what keeps
+# the post-scan group/language filters from starving the candidate list, while
+# preserving the distance ordering the (distance, report_id) ORDER BY relies on
+# (Incremental Sort over the scan's presorted key).
+#
+# Attached as libpq connection options rather than as a database- or server-level
+# default, so the app carries the setting into every environment it connects to
+# (dev, tests, CI, a restored database); production.py extends this dict the same
+# way for the database password.
 DATABASES["default"].setdefault("OPTIONS", {})["options"] = (
-    f"-c hnsw.ef_search={HYBRID_HNSW_EF_SEARCH} -c hnsw.iterative_scan=strict_order"
+    f"-c hnsw.ef_search={min(max(HYBRID_VECTOR_TOP_K, 40), 1000)} "
+    "-c hnsw.iterative_scan=strict_order"
 )
 
 # Chat

--- a/radis/settings/base.py
+++ b/radis/settings/base.py
@@ -530,37 +530,32 @@ EMBEDDINGS_TASK_MAX_ATTEMPTS = 5
 EMBEDDINGS_TASK_EXPONENTIAL_WAIT_SECONDS = 6
 
 # Hybrid search tuning
-HYBRID_VECTOR_TOP_K = _optional_env("HYBRID_VECTOR_TOP_K", int, 500)
 HYBRID_FTS_MAX_RESULTS = 10_000
 HYBRID_RRF_K = 60
-# HYBRID_VECTOR_TOP_K caps the vector half of the fusion; it is not a quota. The
-# HNSW scan makes one pass over the corpus-wide nearest neighbours and the
-# group/language/negation filters then shrink those candidates, so the semantic
-# list is the accessible subset of the corpus's TOP_K nearest and may be shorter
-# than TOP_K. Deliberately no iterative scan to top the list back up: one uniform
-# relevance bar for every group, and one bounded pass instead of digging through
-# up to hnsw.max_scan_tuples inaccessible neighbours under a selective filter.
-#
-# pgvector's hnsw.ef_search (default 40) is both the recall knob and a hard cap
-# on the rows that single pass emits, so it is derived from the top-K slice
-# instead of being its own setting — an independently configured value could
-# drift below the slice and silently truncate the vector half to ~ef_search
-# candidates. The server rejects values above 1000, which therefore also bounds
-# the top-K a single pass can deliver — checked here so a bigger value is a boot
-# error naming the setting, not a silently under-filled slice.
-#
-# Attached as libpq connection options rather than as a database- or server-level
+# The vector half of the fusion is whatever a single HNSW beam pass emits — there
+# is deliberately no separate app-level top-K. hnsw.ef_search is pgvector's beam
+# width and at the same time a hard cap on the rows one index scan emits (default
+# 40, server maximum 1000), so this one setting governs the depth of the semantic
+# side directly. The group/language/negation filters are applied to the emitted
+# candidates afterwards, so the semantic list is the accessible subset of roughly
+# the ef_search nearest reports corpus-wide and shrinks under selective filters.
+# No iterative scan to top it back up: one uniform relevance bar for every group,
+# and one bounded pass instead of digging through up to hnsw.max_scan_tuples
+# inaccessible neighbours — measured on 1.7M reports, merely enabling
+# strict_order cost ~2.4x unfiltered, while below ~5% filter selectivity the
+# scan budget ran out before filling a quota anyway.
+HYBRID_HNSW_EF_SEARCH = _optional_env("HYBRID_HNSW_EF_SEARCH", int, 500)
+if not 1 <= HYBRID_HNSW_EF_SEARCH <= 1000:
+    raise ImproperlyConfigured(
+        f"HYBRID_HNSW_EF_SEARCH={HYBRID_HNSW_EF_SEARCH} must be between 1 and 1000, "
+        "the server's valid hnsw.ef_search range."
+    )
+# Attached as a libpq connection option rather than as a database- or server-level
 # default, so the app carries the setting into every environment it connects to
 # (dev, tests, CI, a restored database); production.py extends this dict the same
 # way for the database password.
-if not 1 <= HYBRID_VECTOR_TOP_K <= 1000:
-    raise ImproperlyConfigured(
-        f"HYBRID_VECTOR_TOP_K={HYBRID_VECTOR_TOP_K} must be between 1 and 1000: a "
-        "single HNSW pass cannot emit more rows than hnsw.ef_search, whose server "
-        "maximum is 1000."
-    )
 DATABASES["default"].setdefault("OPTIONS", {})["options"] = (
-    f"-c hnsw.ef_search={max(HYBRID_VECTOR_TOP_K, 40)}"
+    f"-c hnsw.ef_search={HYBRID_HNSW_EF_SEARCH}"
 )
 
 # Chat


### PR DESCRIPTION
## Problem

pgvector's `hnsw.ef_search` (default **40**) is not only the HNSW recall knob but a hard cap on how many rows a single index scan emits. Nothing in RADIS sets it, so the vector retriever's slice (`HYBRID_VECTOR_TOP_K = 100` at the time) was silently truncated. Measured on a 1.7M-report corpus (1024-dim, `m=16, ef_construction=64`):

| `ef_search` | rows returned at `LIMIT 500` | latency |
|---|---|---|
| 40 (default) | **51** | 6.4 ms |
| 100 | 124 | 7.0 ms |
| 500 | 500 | 27.9 ms |
| 1000 | 500 | 32.1 ms |

So "top 100 nearest" was really "top ~51", and at ef=40 even those ranks were noisy (recall benchmark in the comments: mean R@10 0.894 with a worst-case query at 0.0).

## Fix

**One setting, the physical one: `HYBRID_HNSW_EF_SEARCH`** (env-overridable, default 500, validated against the server's 1..1000 range). It rides along as a **libpq connection option** on the default database and directly governs the depth of the semantic side. `HYBRID_VECTOR_TOP_K` is removed: the vector half of the fusion is whatever a single beam pass emits, so an app-level top-K alongside the beam width was two names for one depth.

- **Semantics: a cap, not a quota.** The scan makes one pass over the corpus-wide nearest neighbours; the group/language/negation filters then shrink those candidates, so the semantic list is the accessible subset of roughly the ef_search nearest reports and shrinks under selective filters — one uniform relevance bar for every group. The queryset keeps a slice only as a planner guard (2× ef_search, above any beam emission, ~1.45× measured) so the query stays on the index path.
- **`hnsw.iterative_scan` is deliberately not enabled.** Measured before dropping (1.7M reports, ef=1000, synthetic `report_id % N` selectivity, warm, real German query terms): merely enabling `strict_order` costs ~2.4× on unfiltered queries (103 vs 43 ms median), and below ~5% selectivity the `hnsw.max_scan_tuples` budget (20k) runs out before a quota fills anyway (238/1000 rows at 1%, 24/1000 at 0.1%, at 3–6× the latency). Engines that guarantee k accessible results (Elasticsearch, OpenSearch, Qdrant, Vespa, Weaviate) rely on filter-aware graph traversal pgvector doesn't have. **Revisit trigger:** if a deployment hosts groups owning a small fraction of the corpus, their semantic contribution thins by design — the honest fixes then are partial indexes or filter-aware indexing, not iterative scan.
- Connection option rather than `ALTER DATABASE` or a server flag, so the app carries the setting into every environment it connects to (dev, tests, CI, a restored database) — same pattern as `production.py` extending `DATABASES["default"]` for the password. Zero per-query cost.
- The vector half is one complete beam pass by definition, so it no longer makes `total_relation` a lower bound; only a truncated FTS side does.

## Test plan

- Test asserts via `SHOW` that the Django connection carries the configured `ef_search` and that `iterative_scan` is `off` (one-pass semantics is deliberate), forcing the pgvector library load first since the lazily-defined GUC otherwise errors the `SHOW` — passes against a stock pgvector container.
- `radis/pgsearch` + `radis/search` suites: 239 passed. `uv run cli lint` clean.
- Verified on a staging deployment with 1.7M embedded reports: vector candidate list went from ~51 to the full beam; recall vs exact ground truth at ef=500: R@10 0.998, R@500 0.979 (tables in comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDei6anDxfR5eoHhFfXBGs
