### PR TITLE
Optional BM25 FTS ranking via pg_textsearch

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,0 +1,32 @@
+# Postgres image for RADIS with both search extensions: pgvector (same pinned
+# upstream the compose files use) plus pg_textsearch (Timescale's BM25 ranking,
+# PostgreSQL-licensed). Built from source at a pinned tag - pg_textsearch is a
+# plain C extension, so the build needs only the server headers.
+#
+# Build:   docker build -t radis-postgres:pg17-bm25 docker/postgres
+# Use:     point the compose postgres service's image at the built tag.
+# The stock pinned pgvector image keeps working for deployments that leave
+# HYBRID_FTS_RANKING at its default; this image is required only for "bm25".
+
+FROM pgvector/pgvector:pg17@sha256:cf134a767f474095eeba57e0117be8e568e011a63f33fbf252f14c9b760f8e6f AS builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential git ca-certificates postgresql-server-dev-17 \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG PG_TEXTSEARCH_VERSION=v1.4.0
+RUN git clone --depth 1 --branch ${PG_TEXTSEARCH_VERSION} \
+        https://github.com/timescale/pg_textsearch /tmp/pg_textsearch \
+    && make -C /tmp/pg_textsearch \
+    && make -C /tmp/pg_textsearch install
+
+FROM pgvector/pgvector:pg17@sha256:cf134a767f474095eeba57e0117be8e568e011a63f33fbf252f14c9b760f8e6f
+
+COPY --from=builder /usr/lib/postgresql/17/lib/pg_textsearch* /usr/lib/postgresql/17/lib/
+COPY --from=builder /usr/share/postgresql/17/extension/pg_textsearch* /usr/share/postgresql/17/extension/
+
+# pg_textsearch must be preloaded at server start (it refuses CREATE EXTENSION
+# otherwise). A command-line GUC applies regardless of how old the data volume
+# is, unlike a postgresql.conf baked at initdb time.
+CMD ["postgres", "-c", "shared_preload_libraries=pg_textsearch"]

--- a/radis/pgsearch/apps.py
+++ b/radis/pgsearch/apps.py
@@ -2,7 +2,7 @@ import logging
 
 from django.apps import AppConfig
 from django.conf import settings
-from django.core.checks import Error, register
+from django.core.checks import Error, Tags, register
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +104,61 @@ def check_embeddings_dimensions_param(app_configs, **kwargs):
             ),
         )
     ]
+
+
+@register(Tags.database)
+def check_bm25_ranking_prerequisites(app_configs, databases=None, **kwargs):
+    """When HYBRID_FTS_RANKING='bm25', the pg_textsearch extension and one BM25
+    index per Language row must exist — a missing piece would otherwise surface
+    as an opaque SQL error on the first search instead of at deploy time. Runs
+    as a database check (during migrate), which is when the init container can
+    still fail loudly."""
+    if settings.HYBRID_FTS_RANKING != "bm25":
+        return []
+    if databases is not None and "default" not in databases:
+        return []
+
+    from django.db import connection
+
+    from radis.reports.models import Language, Report
+
+    from .utils.bm25_utils import bm25_index_name
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT 1 FROM pg_extension WHERE extname = 'pg_textsearch'")
+        if cursor.fetchone() is None:
+            return [
+                Error(
+                    "HYBRID_FTS_RANKING='bm25' but the pg_textsearch extension is not "
+                    "installed in the database.",
+                    id="pgsearch.E004",
+                    hint=(
+                        "Use a postgres image that ships pg_textsearch (see "
+                        "docker/postgres/Dockerfile) and run `manage.py sync_bm25_indexes`."
+                    ),
+                )
+            ]
+        cursor.execute(
+            "SELECT indexname FROM pg_indexes WHERE tablename = %s",
+            [Report._meta.db_table],
+        )
+        existing = {row[0] for row in cursor.fetchall()}
+
+    missing = sorted(
+        bm25_index_name(code)
+        for code in Language.objects.values_list("code", flat=True)
+        if bm25_index_name(code) not in existing
+    )
+    if missing:
+        return [
+            Error(
+                f"HYBRID_FTS_RANKING='bm25' but BM25 indexes are missing: "
+                f"{', '.join(missing)}.",
+                id="pgsearch.E005",
+                hint="Run `manage.py sync_bm25_indexes`.",
+            )
+        ]
+    return []
 
 
 def _index_reports(reports):

--- a/radis/pgsearch/management/commands/sync_bm25_indexes.py
+++ b/radis/pgsearch/management/commands/sync_bm25_indexes.py
@@ -1,0 +1,69 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection
+
+from radis.reports.models import Language, Report
+
+from ...utils.bm25_utils import bm25_index_name
+from ...utils.language_utils import code_to_language
+
+
+class Command(BaseCommand):
+    help = (
+        "Create the pg_textsearch extension and one partial BM25 index per Language "
+        "row (used when HYBRID_FTS_RANKING='bm25'). Languages are data, not schema, "
+        "so the indexes are managed here instead of in migrations: adding a language "
+        "to the corpus means re-running this command, not writing a migration. "
+        "Index builds take a table lock and scale with corpus size."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Only report what would be created.",
+        )
+
+    def handle(self, *args, **options):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1 FROM pg_available_extensions WHERE name = 'pg_textsearch'")
+            if cursor.fetchone() is None:
+                raise CommandError(
+                    "pg_textsearch is not available in this PostgreSQL installation. "
+                    "Use a postgres image that ships it (see docker/postgres/Dockerfile)."
+                )
+            if not options["dry_run"]:
+                cursor.execute("CREATE EXTENSION IF NOT EXISTS pg_textsearch")
+
+            # Inside an enclosing transaction (tests, scripted setups) freshly
+            # written rows leave deferred FK trigger events pending, and CREATE
+            # INDEX refuses to run over them; firing them now clears the queue.
+            # A no-op under autocommit.
+            cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+            table = Report._meta.db_table
+            cursor.execute("SELECT indexname FROM pg_indexes WHERE tablename = %s", [table])
+            existing = {row[0] for row in cursor.fetchall()}
+
+            for language in Language.objects.all():
+                name = bm25_index_name(language.code)
+                if name in existing:
+                    self.stdout.write(f"{name}: exists")
+                    continue
+                config = code_to_language(language.code)
+                if options["dry_run"]:
+                    self.stdout.write(f"{name}: would create (text_config={config})")
+                    continue
+                self.stdout.write(f"{name}: creating (text_config={config}) ...")
+                # The predicate pins the index to one language so each index
+                # carries a single stemmer and its own coherent BM25 statistics.
+                # DDL takes no bind parameters, so everything is inlined from
+                # vetted parts: the index name sanitizes the language code, the
+                # table comes from model meta, the config from our own closed
+                # code_to_language mapping (asserted below), the id is an int.
+                if not config.isidentifier():
+                    raise CommandError(f"Unexpected text search config name: {config!r}")
+                cursor.execute(
+                    f'CREATE INDEX "{name}" ON "{table}" USING bm25 (body) '
+                    f"WITH (text_config='{config}') WHERE language_id = {int(language.pk)}"
+                )
+                self.stdout.write(f"{name}: done")

--- a/radis/pgsearch/providers.py
+++ b/radis/pgsearch/providers.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.contrib.postgres.search import SearchHeadline, SearchQuery, SearchRank
 from django.core.cache import cache
 from django.db.models import Case, F, FloatField, Q, TextField, Value, When
+from django.db.models.expressions import RawSQL
 from pgvector.django import CosineDistance
 
 from radis.core.utils.embedding_client import (
@@ -32,6 +33,7 @@ from radis.search.utils.query_parser import (
 )
 
 from .models import ReportSearchIndex
+from .utils.bm25_utils import bm25_index_name
 from .utils.document_utils import AnnotatedReportSearchIndex, document_from_pgsearch_response
 from .utils.fusion import rrf_fuse, summary_with_fallback
 from .utils.language_utils import code_to_language
@@ -342,6 +344,54 @@ class _FusedHybrid(NamedTuple):
     query_str: str
 
 
+def _bm25_fts_rows(
+    search: Search,
+    filter_query: Q,
+    match_q: Q,
+    configs: list[tuple[str, list[str]]],
+) -> list[dict]:
+    """FTS candidates ranked by BM25 (pg_textsearch) instead of ts_rank.
+
+    Membership is unchanged: the boolean tsquery match still gates which
+    documents qualify, so AND/OR/NOT and phrase semantics are exactly those of
+    the ts_rank path. Only the *ordering* differs — ``body <@> to_bm25query``
+    scores with corpus-level IDF out of the per-language BM25 index (see
+    sync_bm25_indexes) instead of computing ts_rank for every match. Ranking is
+    per language because BM25 statistics live per index; scores from different
+    languages are merged as-is, an approximation in a mixed corpus — the same
+    caveat the per-config ts_rank Case carries, since ts_rank values from
+    different stemmers aren't comparable either. ``<@>`` returns negative
+    scores (more negative = better), hence ascending order and the sign flip.
+    """
+    text = QueryParser.unparse_for_embedding(search.query)
+    if not text.strip():
+        return []
+    scored: list[tuple[float, int]] = []
+    for _config, codes in configs:
+        for code in codes:
+            rows = (
+                ReportSearchIndex.objects.filter(filter_query)
+                .distinct()
+                .filter(match_q)
+                .filter(report__language__code=code)
+                .annotate(
+                    score=RawSQL(
+                        "reports_report.body <@> to_bm25query(%s, %s)",
+                        (text, bm25_index_name(code)),
+                        output_field=FloatField(),
+                    )
+                )
+                .order_by("score", "report_id")
+                .values_list("report_id", "score")[: settings.HYBRID_FTS_MAX_RESULTS]
+            )
+            scored.extend((score, rid) for rid, score in rows)
+    scored.sort()
+    return [
+        {"report_id": rid, "rank": -score}
+        for score, rid in scored[: settings.HYBRID_FTS_MAX_RESULTS]
+    ]
+
+
 # Bumped whenever the cached payload's shape changes, so entries written by an
 # older code version are missed rather than misread.
 _FUSED_CACHE_SCHEMA = 1
@@ -361,6 +411,7 @@ def _fused_cache_key(search: Search) -> str:
             "query": QueryParser.unparse(search.query),
             "filters": asdict(search.filters),
             "fts_max": settings.HYBRID_FTS_MAX_RESULTS,
+            "fts_ranking": settings.HYBRID_FTS_RANKING,
             "rrf_k": settings.HYBRID_RRF_K,
             "ef_search": settings.HYBRID_HNSW_EF_SEARCH,
             "embeddings": None
@@ -506,10 +557,12 @@ def _fuse_hybrid_uncached(search: Search, caller: str) -> tuple[_FusedHybrid, bo
     # FTS side: bounded set, ts_rank only (no headline at this stage). An empty
     # ``configs`` means an empty corpus (Report.language is a required FK), and
     # an empty match_q would match every row rather than none, so skip it.
-    fts_rows = (
-        []
-        if not configs
-        else list(
+    if not configs:
+        fts_rows = []
+    elif settings.HYBRID_FTS_RANKING == "bm25":
+        fts_rows = _bm25_fts_rows(search, filter_query, match_q, configs)
+    else:
+        fts_rows = list(
             ReportSearchIndex.objects.filter(filter_query)
             .distinct()
             .filter(match_q)
@@ -517,7 +570,6 @@ def _fuse_hybrid_uncached(search: Search, caller: str) -> tuple[_FusedHybrid, bo
             .order_by("-rank", "report_id")
             .values("report_id", "rank")[: settings.HYBRID_FTS_MAX_RESULTS]
         )
-    )
     fts_rank = {row["report_id"]: i + 1 for i, row in enumerate(fts_rows)}
 
     # Fusion.

--- a/radis/pgsearch/tests/test_bm25_ranking.py
+++ b/radis/pgsearch/tests/test_bm25_ranking.py
@@ -1,0 +1,114 @@
+import pytest
+from django.contrib.auth.models import Group
+from django.core.cache import cache
+from django.core.management import call_command
+from django.db import connection
+
+from radis.pgsearch.apps import check_bm25_ranking_prerequisites
+from radis.pgsearch.providers import search
+from radis.pgsearch.utils.bm25_utils import bm25_index_name
+from radis.reports.factories import ReportFactory
+from radis.reports.models import Report
+from radis.search.site import Search, SearchFilters
+from radis.search.utils.query_parser import QueryParser
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def _requires_pg_textsearch(db):
+    """These tests need a postgres that ships pg_textsearch (see
+    docker/postgres/Dockerfile); on a stock pgvector image they skip rather
+    than fail, so the default CI database keeps passing."""
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT 1 FROM pg_available_extensions WHERE name = 'pg_textsearch'")
+        if cursor.fetchone() is None:
+            pytest.skip("pg_textsearch is not available in this PostgreSQL installation")
+
+
+@pytest.fixture(autouse=True)
+def _bm25_mode(settings):
+    settings.HYBRID_FTS_RANKING = "bm25"
+    # Isolate the FTS ordering: with no embedding model the fused order is the
+    # FTS order, so assertions test BM25 ranking and nothing else.
+    settings.EMBEDDINGS_MODEL = None
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _make_report(body: str) -> Report:
+    return ReportFactory.create(body=body, language__code="en")
+
+
+def _make_search(query_str: str, group_id: int) -> Search:
+    node, _ = QueryParser().parse(query_str)
+    assert node is not None
+    return Search(
+        query=node,
+        filters=SearchFilters(group=group_id, language="en"),
+        offset=0,
+        limit=25,
+    )
+
+
+@pytest.fixture
+def group(db):
+    return Group.objects.create(name="radiology")
+
+
+def test_sync_bm25_indexes_creates_extension_and_per_language_indexes(group):
+    _make_report(body="pneumothorax")  # creates the Language row
+
+    call_command("sync_bm25_indexes")
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT 1 FROM pg_extension WHERE extname = 'pg_textsearch'")
+        assert cursor.fetchone() is not None
+        cursor.execute(
+            "SELECT 1 FROM pg_indexes WHERE indexname = %s", [bm25_index_name("en")]
+        )
+        assert cursor.fetchone() is not None
+
+    # Idempotent: a second run must not fail on the existing index.
+    call_command("sync_bm25_indexes")
+
+
+def test_bm25_ranks_by_term_frequency(group):
+    r_once = _make_report(body="A single pneumothorax mention in a longer report body.")
+    r_many = _make_report(body="Pneumothorax confirmed. Pneumothorax unchanged. Pneumothorax.")
+    r_none = _make_report(body="Lungs are clear bilaterally.")
+    for r in (r_once, r_many, r_none):
+        r.groups.add(group)
+    call_command("sync_bm25_indexes")
+
+    result = search(_make_search("pneumothorax", group.pk))
+
+    ids = [d.document_id for d in result.documents]
+    assert ids == [r_many.document_id, r_once.document_id]
+    assert r_none.document_id not in ids
+
+
+def test_boolean_semantics_still_gate_membership(group):
+    r_plain = _make_report(body="Pneumothorax on the left side.")
+    r_negated = _make_report(body="Pneumothorax with drainage in place.")
+    for r in (r_plain, r_negated):
+        r.groups.add(group)
+    call_command("sync_bm25_indexes")
+
+    result = search(_make_search("pneumothorax AND NOT drainage", group.pk))
+
+    ids = [d.document_id for d in result.documents]
+    assert ids == [r_plain.document_id]
+
+
+def test_database_check_reports_missing_indexes_then_passes(group):
+    _make_report(body="pneumothorax")
+    with connection.cursor() as cursor:
+        cursor.execute("CREATE EXTENSION IF NOT EXISTS pg_textsearch")
+
+    errors = check_bm25_ranking_prerequisites(None, databases=["default"])
+    assert [e.id for e in errors] == ["pgsearch.E005"]
+
+    call_command("sync_bm25_indexes")
+    assert check_bm25_ranking_prerequisites(None, databases=["default"]) == []

--- a/radis/pgsearch/utils/bm25_utils.py
+++ b/radis/pgsearch/utils/bm25_utils.py
@@ -1,0 +1,12 @@
+import re
+
+
+def bm25_index_name(language_code: str) -> str:
+    """Name of the per-language partial BM25 index on reports_report.
+
+    One index per language because BM25 statistics live per index and a
+    pg_textsearch index carries a single text_config; the language code is
+    sanitized because it becomes part of a SQL identifier.
+    """
+    safe = re.sub(r"[^a-z0-9_]", "_", language_code.lower())
+    return f"pgsearch_bm25_body_{safe}"

--- a/radis/settings/base.py
+++ b/radis/settings/base.py
@@ -565,6 +565,18 @@ DATABASES["default"].setdefault("OPTIONS", {})["options"] = (
 # only after it expires. 0 disables the cache. Degraded FTS-only results
 # (configured embedding model, no vector) are never cached.
 HYBRID_FUSED_CACHE_TIMEOUT_SECONDS = _optional_env("HYBRID_FUSED_CACHE_TIMEOUT_SECONDS", int, 300)
+# How the FTS half of the fusion ranks its matches. "ts_rank" is PostgreSQL's
+# built-in ranking: no extension needed, but every match is scored per query —
+# seconds for a common term on a large corpus — and it carries no corpus-level
+# IDF. "bm25" ranks via the pg_textsearch extension (index-backed BM25): needs
+# the extension in the postgres image (docker/postgres/Dockerfile) and one
+# partial index per language (manage.py sync_bm25_indexes); membership still
+# comes from the boolean tsquery match either way, only the ordering changes.
+HYBRID_FTS_RANKING = _optional_env("HYBRID_FTS_RANKING", str, "ts_rank")
+if HYBRID_FTS_RANKING not in ("ts_rank", "bm25"):
+    raise ImproperlyConfigured(
+        f"HYBRID_FTS_RANKING={HYBRID_FTS_RANKING!r} must be 'ts_rank' or 'bm25'."
+    )
 
 # Chat
 CHAT_GENERATE_TITLE_SYSTEM_PROMPT = """


### PR DESCRIPTION
> **Draft**, stacked on #284 (which stacks on #282). Follows the direction @medihack pointed at in https://github.com/openradx/radis/pull/64#issuecomment — pg_textsearch over ParadeDB — and is meant to make that evaluation concrete. Opt-in and inert by default.

## Motivation (measured)

The FTS half of hybrid search ranks **every** match before its LIMIT applies. On a 1.7M-report corpus, "fraktur" matches 414,572 reports; one fusion costs **11–12 s** (6.8 s of it `ts_rank` + sort, plan: parallel seq scan + top-N heapsort), per page. `ts_rank` also carries no corpus-level IDF — a match on a term appearing in 414k documents weighs the same as one appearing in 12. Both problems grow with the corpus; #284 amortizes the cost across pages, this PR is the structural fix: BM25 ranking out of an index (Block-Max WAND top-k), with IDF.

## Why pg_textsearch and not PR #64's ParadeDB

Per the maintainer's comments there: paradedb#1793 (per-record language stemming) blocks ParadeDB — its per-index stemmer forces languages into schema (generated columns). pg_textsearch is PostgreSQL-licensed, builds on Postgres's own text search configs, and its documented multilingual pattern — **one partial BM25 index per language** — keeps language as *data*: this PR manages the indexes from the `Language` table at runtime (`sync_bm25_indexes`), not in migrations. Adding a language to a corpus means re-running a command, not writing a migration.

## What's here

- `docker/postgres/Dockerfile` — the pinned pgvector image + pg_textsearch **v1.4.0** built from source (plain C extension), `shared_preload_libraries` set (it refuses to load otherwise — note: adopting this means one postgres restart).
- `HYBRID_FTS_RANKING = ts_rank | bm25` (default **ts_rank** — nothing changes until a deployment opts in; participates in #284's cache key).
- `manage.py sync_bm25_indexes` — creates the extension and one partial index per `Language` row (`text_config` via the existing `code_to_language` mapping).
- Provider: in bm25 mode the boolean tsquery match **still gates membership** — AND/OR/NOT and phrase semantics are unchanged — while `body <@> to_bm25query(...)` provides the ordering. Per-language ranking (BM25 statistics live per index), merged by score with the caveat documented (mixed-corpus scores are approximate — as are cross-stemmer `ts_rank` values today).
- Database checks `pgsearch.E004`/`E005`: bm25 selected but extension/indexes missing fails at `migrate` (init container), not on the first search.
- Tests that **skip on a stock pgvector image**, so CI stays green without the extension.

## Verified

- pg_textsearch **1.4.0 and vector 0.8.6 coexist** in one database on the built image.
- German partial index builds; BM25 behaves (term-frequency saturation visible; non-matching docs score 0 — confirming membership must come from the filter, as implemented).
- 4 new tests green against the BM25 image; full `pgsearch` + `search` suites green on both images; lint clean.

## Open questions for review

1. **Query shape vs. index acceleration**: with the membership filter and group join in the query, does the planner drive the BM25 index for top-k, or score per row? v1.4.0's release notes claim up-to-5× filtered top-k optimizations; a staging-scale benchmark (1.7M reports) is the follow-up before any default change.
2. **Maturity**: the extension is young (open-sourced 2026). The default stays `ts_rank` until we're comfortable.
3. `sync_bm25_indexes` builds take a table lock and scale with corpus size — acceptable as an operator-run step?
4. Mixed-corpus score merging across per-language indexes (documented caveat) — acceptable, or rank-interleave instead?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDei6anDxfR5eoHhFfXBGs
