### PR TITLE
Remove unused subscription retrieval provider

### DIFF
--- a/radis/pgsearch/apps.py
+++ b/radis/pgsearch/apps.py
@@ -157,9 +157,7 @@ def register_app():
     from radis.search.site import SearchProvider, register_search_provider
     from radis.subscriptions.site import (
         SubscriptionFilterProvider,
-        SubscriptionRetrievalProvider,
         register_subscription_filter_provider,
-        register_subscription_retrieval_provider,
     )
 
     from .providers import count, filter, retrieve, search
@@ -186,12 +184,6 @@ def register_app():
         )
     )
 
-    register_subscription_retrieval_provider(
-        SubscriptionRetrievalProvider(
-            name="PG Search",
-            retrieve=retrieve,
-        )
-    )
     register_subscription_filter_provider(
         SubscriptionFilterProvider(
             name="PG Search",

--- a/radis/subscriptions/site.py
+++ b/radis/subscriptions/site.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Iterable
 from typing import NamedTuple
 
-from radis.search.site import Search, SearchFilters
+from radis.search.site import SearchFilters
 
 
 class SubscriptionFilterProvider(NamedTuple):
@@ -9,10 +9,7 @@ class SubscriptionFilterProvider(NamedTuple):
 
     Attributes:
     - name: The name of the filter provider.
-    - count: A function that counts the number of results for a search.
-    - filter: A function that returns the document IDs for a filter.
-    - max_results: The maximum number of results that can be returned by this provider,
-      or None if there is no limit.
+    - filter: A function that returns the document IDs matching the filters.
     """
 
     name: str
@@ -25,23 +22,3 @@ subscription_filter_provider: SubscriptionFilterProvider | None = None
 def register_subscription_filter_provider(provider: SubscriptionFilterProvider):
     global subscription_filter_provider
     subscription_filter_provider = provider
-
-
-class SubscriptionRetrievalProvider(NamedTuple):
-    """A class representing a retrieval provider.
-
-    Attributes:
-    - name: The name of the retrieval provider.
-    - retrieve: A function that retrieves the document IDs for a search.
-    """
-
-    name: str
-    retrieve: Callable[[Search], Iterable[str]]
-
-
-subscription_retrieval_provider: SubscriptionRetrievalProvider | None = None
-
-
-def register_subscription_retrieval_provider(provider: SubscriptionRetrievalProvider):
-    global subscription_retrieval_provider
-    subscription_retrieval_provider = provider


### PR DESCRIPTION
Closes #291

**Problem:** `radis/pgsearch/apps.py` registered a `SubscriptionRetrievalProvider` wrapping `retrieve()`, but nothing ever read it. Subscription refreshes use the filter provider, which iterates the full queryset, whereas `retrieve()` goes through hybrid fusion and caps results. The dead registration was a trap: wiring it up later would silently cap subscriptions.

**Fix:** Removed the `SubscriptionRetrievalProvider` type, its registry slot, and the registration in the PG Search app. Trimmed the filter provider docstring to the attributes it actually has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WN9ThGmgVfKJULyG82d25r


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Subscription filtering now uses a streamlined provider interface with only its name and filtering behavior.
  * The subscription retrieval provider integration has been removed from application registration.
  * The standalone subscription retrieval provider API and its registration mechanism are no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->