### PR TITLE
Bump adit-radis-shared to 0.28.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ default-groups = ["dev", "client", "docs"]
 constraint-dependencies = ["autobahn<25.11.1"]
 
 [tool.uv.sources]
-adit-radis-shared = { git = "https://github.com/openradx/adit-radis-shared.git", tag = "0.27.0" }
+adit-radis-shared = { git = "https://github.com/openradx/adit-radis-shared.git", tag = "0.28.0" }
 radis-client = { path = "./radis-client", editable = true }
 
 [tool.pyright]

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ constraints = [{ name = "autobahn", specifier = "<25.11.1" }]
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?tag=0.27.0#b081ea48fc250b0a6ad9a5c8e852dd6ddeeaf2b0" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?tag=0.28.0#15e8bb3ad885e1838e832cf506531a8dc74faacf" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },
@@ -2876,7 +2876,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?tag=0.27.0" },
+    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?tag=0.28.0" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },


### PR DESCRIPTION
Moves the pinned `adit-radis-shared` tag from `0.27.0` to `0.28.0`, so RADIS picks up the shared library changes that landed alongside #296:

- the `MAILERS` migration in the shared example project
- the `Django>=6.1` floor (RADIS already declares and locks 6.1 after #296, so nothing moves here)
- the djlint 1.45 fixes to the shared templates RADIS renders — `common/`, `registration/` and `token_authentication/`

The lock delta is a single line: `adit-radis-shared b081ea48 → 15e8bb3a`. Nothing else resolves differently.

`0.28.0` tags adit-radis-shared `15e8bb3`, which is green on its main.

## Verification

- `pytest -m "not acceptance"`: **915 passed**
- `ruff check`, `pyright`, `djlint --lint`: clean

Not run locally: the Playwright acceptance tests (they need the dev containers built).

## Related

ADIT counterpart: openradx/adit#408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4uip5n3TwDXh6tHuoDsuc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the shared `adit-radis` component to version 0.28.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->