### PR TITLE
Bump adit-radis-shared to 0.28.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ default-groups = ["dev", "client", "docs"]
 constraint-dependencies = ["autobahn<25.11.1"]
 
 [tool.uv.sources]
-adit-radis-shared = { git = "https://github.com/openradx/adit-radis-shared.git", tag = "0.28.0" }
+adit-radis-shared = { git = "https://github.com/openradx/adit-radis-shared.git", tag = "0.28.1" }
 radis-client = { path = "./radis-client", editable = true }
 
 [tool.pyright]

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ constraints = [{ name = "autobahn", specifier = "<25.11.1" }]
 [[package]]
 name = "adit-radis-shared"
 version = "0.0.0"
-source = { git = "https://github.com/openradx/adit-radis-shared.git?tag=0.28.0#15e8bb3ad885e1838e832cf506531a8dc74faacf" }
+source = { git = "https://github.com/openradx/adit-radis-shared.git?tag=0.28.1#c0f1bba83d2a372d1b4f955aab1e91bba0b2f7ee" }
 dependencies = [
     { name = "channels" },
     { name = "crispy-bootstrap5" },
@@ -2876,7 +2876,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?tag=0.28.0" },
+    { name = "adit-radis-shared", git = "https://github.com/openradx/adit-radis-shared.git?tag=0.28.1" },
     { name = "adrf", specifier = ">=0.1.9" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "asyncinotify", specifier = ">=4.2.0" },


### PR DESCRIPTION
Picks up openradx/adit-radis-shared#247, which makes `run_worker_once()` cope with a connector that already runs workers.

RADIS does not call that helper, so this changes nothing here in practice — it keeps RADIS on the same shared tag as ADIT rather than drifting a patch version behind.

Lock delta is a single line: `adit-radis-shared 15e8bb3a → c0f1bba8`.

## Verification

- `pytest -m "not acceptance"`: **915 passed**
- `ruff check`, `pyright`: clean

Not run locally: the Playwright acceptance tests (they need the dev containers built).

## Related

ADIT counterpart: openradx/adit#409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4uip5n3TwDXh6tHuoDsuc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying shared component to version 0.28.1 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->